### PR TITLE
Deploy cmd reboot flag

### DIFF
--- a/morph.go
+++ b/morph.go
@@ -36,7 +36,7 @@ var (
 	deploy              = deployCmd(app.Command("deploy", "Deploy machines"))
 	deploySwitchAction  string
 	deployUploadSecrets bool
-	deployReboot		bool
+	deployReboot        bool
 	skipHealthChecks    bool
 	healthCheck         = healthCheckCmd(app.Command("check-health", "Run health checks"))
 	uploadSecrets       = uploadSecretsCmd(app.Command("upload-secrets", "Upload secrets"))


### PR DESCRIPTION
This is the initial implementation of `morph deploy --reboot` which can be used to reboot hosts after system activation but prior to healthcheck execution.

There might still be issues with the implementation of healthcheck timeouts as well as SSH cmd exec timeout values, but I consider testing and potential fixing of these not to be in scope of this PR.

In a future version of Morph most of the current reboot logic should be moved to a backend module instead of living in /morph.go.
