### PR TITLE
Make the target NixOS system depend on healthcheck deps

### DIFF
--- a/data/options.nix
+++ b/data/options.nix
@@ -180,4 +180,13 @@ in
       default = {};
     };
   };
+
+  # Creates a txt-file that lists all system healthcheck commands
+  # The file will end up linked in /run/current-system along with
+  # all derived dependencies.
+  config.system.extraDependencies =
+  let
+    cmds = concatMap (h: h.cmd) config.deployment.healthChecks.cmd;
+  in
+  [ (pkgs.writeText "healthcheck-commands.txt" (concatStringsSep "\n" cmds)) ];
 }


### PR DESCRIPTION
This change ensures that dependencies of command healthchecks will always end up in the dependency graph for the target NixOS system.

Ultimately this allows for command healthchecks defined like this:

```nix
{
  cmd = ["${pkgs.curl}/bin/curl" "-sSf" "http://localhost:8080"];
}
```
without the need of having pkgs.curl in `environment.systemPackages`.
