### PR TITLE
Upload secrets mkdir parents

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,8 +118,10 @@ Files can be uploaded without ever ending up in the nix store, by specifying eac
 
 See `examples/secrets.nix` or the type definitions in `data/options.nix`.
 
-Here be dragons:
-Morph currently doesn't have support for creating the required directory structure, so uploading a file to a non-existing directory will fail.
+*Note:*
+Morph will automatically create directories parent to `secret.Destination` if they don't exist.
+New dirs will be owned by root:root and have mode 755 (drwxr-xr-w).
+Automatic directory creation can be disabled by setting `secret.mkDirs = false`.
 
 
 ### Health checks

--- a/data/options.nix
+++ b/data/options.nix
@@ -52,6 +52,16 @@ keyOptionsType = submodule ({ ... }: {
       type = listOf str;
       description = "Action to perform on remote host after uploading secret.";
     };
+
+    mkDirs = mkOption {
+      default = true;
+      type = bool;
+      description = ''
+        Whether to create parent directories to secret destination.
+        In particular, morph will execute `sudo mkdir -p -m 755 /path/to/secret/destination`
+        prior to moving the secret in place.
+      '';
+    };
   };
 });
 

--- a/secrets/secrets.go
+++ b/secrets/secrets.go
@@ -4,6 +4,7 @@ import (
 	"github.com/dbcdk/morph/ssh"
 	"github.com/dbcdk/morph/utils"
 	"os"
+	"path/filepath"
 )
 
 type SecretError struct {
@@ -48,6 +49,12 @@ func UploadSecret(ctx ssh.Context, host ssh.Host, secret Secret, deploymentWD st
 	tempPath, err := ctx.MakeTempFile(host)
 	if err != nil {
 		return wrap(err)
+	}
+
+	if secret.MkDirs {
+		if err := ctx.MakeDirs(host, filepath.Dir(secret.Destination), true, 0755); err != nil {
+			return wrap(err)
+		}
 	}
 
 	err = ctx.UploadFile(host, utils.GetAbsPathRelativeTo(secret.Source, deploymentWD), tempPath)

--- a/secrets/types.go
+++ b/secrets/types.go
@@ -6,6 +6,7 @@ type Secret struct {
 	Owner       Owner
 	Permissions string
 	Action      []string
+	MkDirs      bool
 }
 
 type Owner struct {


### PR DESCRIPTION
Implements #16 

New default is to always create parent directories for secrets if they don't exist. I've added a note about this in the README.
