### PR TITLE
Lets include best practise in the examples by pinning the version of nixpkgs

### DIFF
--- a/examples/healthchecks.nix
+++ b/examples/healthchecks.nix
@@ -1,6 +1,13 @@
+let
+  # Pin the deployment package-set to a specific version of nixpkgs
+  pkgs = import (builtins.fetchTarball {
+    url = "https://github.com/NixOS/nixpkgs-channels/archive/98c1150f2cc62b94b693dce63adc1fbcbfe616f1.tar.gz";
+    sha256 = "1mdwn0qrjc8jli8cbi4cfkar6xq15l232r371p4b48v2d4bah3wp";
+  }) {};
+in
 {
   network =  {
-    pkgs = import <nixpkgs> {};
+    inherit pkgs;
     description = "health check demo hosts";
   };
 

--- a/examples/secrets.nix
+++ b/examples/secrets.nix
@@ -1,6 +1,13 @@
+let
+  # Pin the deployment package-set to a specific version of nixpkgs
+  pkgs = import (builtins.fetchTarball {
+    url = "https://github.com/NixOS/nixpkgs-channels/archive/98c1150f2cc62b94b693dce63adc1fbcbfe616f1.tar.gz";
+    sha256 = "1mdwn0qrjc8jli8cbi4cfkar6xq15l232r371p4b48v2d4bah3wp";
+  }) {};
+in
 {
   network =  {
-    pkgs = import <nixpkgs> {};
+    inherit pkgs;
     description = "webserver with secrets";
   };
 

--- a/examples/simple.nix
+++ b/examples/simple.nix
@@ -1,6 +1,13 @@
+let
+  # Pin the deployment package-set to a specific version of nixpkgs
+  pkgs = import (builtins.fetchTarball {
+    url = "https://github.com/NixOS/nixpkgs-channels/archive/98c1150f2cc62b94b693dce63adc1fbcbfe616f1.tar.gz";
+    sha256 = "1mdwn0qrjc8jli8cbi4cfkar6xq15l232r371p4b48v2d4bah3wp";
+  }) {};
+in
 {
   network =  {
-    pkgs = import <nixpkgs> {};
+    inherit pkgs;
     description = "simple hosts";
   };
 


### PR DESCRIPTION
See this thread: https://www.reddit.com/r/NixOS/comments/9uh8ff/morph_nixos_deployment_tool/

We should not recommend importing the local set of nixpkgs on the deploying machine.
