### PR TITLE
Make scp honor SSH_USER and SSH_IDENTIFY_FILE

### DIFF
--- a/secrets/secrets.go
+++ b/secrets/secrets.go
@@ -15,6 +15,7 @@ type SecretError struct {
 func wrap(err error) *SecretError {
 	return &SecretError{
 		Err: err,
+		Fatal: true,
 	}
 }
 

--- a/ssh/ssh.go
+++ b/ssh/ssh.go
@@ -240,6 +240,15 @@ func (ctx *SSHContext) MakeTempFile(host Host) (path string, err error) {
 
 func (ctx *SSHContext) UploadFile(host Host, source string, destination string) (err error) {
 	destinationAndHost := host.GetTargetHost() + ":" + destination
+
+	parts := []string{"scp"}
+	if ctx.IdentityFile != "" {
+		parts = append(parts, "-i", ctx.IdentityFile)
+	}
+	if ctx.Username != "" {
+		destinationAndHost = ctx.Username + "@" + destinationAndHost
+	}
+
 	cmd := exec.Command(
 		"scp", source, destinationAndHost,
 	)


### PR DESCRIPTION
Warning warning warning: This also properly makes fatal errors fatal, despite them not being fatal before doing to fatal being left unset (this change is a prerequisite to making scp fail properly).