### PR TITLE
Make scp honor SSH_IDENTITY_FILE and SSH_USER

### DIFF
--- a/secrets/secrets.go
+++ b/secrets/secrets.go
@@ -15,6 +15,7 @@ type SecretError struct {
 func wrap(err error) *SecretError {
 	return &SecretError{
 		Err: err,
+		Fatal: true,
 	}
 }
 

--- a/ssh/ssh.go
+++ b/ssh/ssh.go
@@ -240,9 +240,18 @@ func (ctx *SSHContext) MakeTempFile(host Host) (path string, err error) {
 
 func (ctx *SSHContext) UploadFile(host Host, source string, destination string) (err error) {
 	destinationAndHost := host.GetTargetHost() + ":" + destination
-	cmd := exec.Command(
-		"scp", source, destinationAndHost,
-	)
+
+	parts := make([]string, 0)
+	if ctx.IdentityFile != "" {
+		parts = append(parts, "-i", ctx.IdentityFile)
+	}
+	if ctx.Username != "" {
+		destinationAndHost = ctx.Username + "@" + destinationAndHost
+	}
+
+	parts = append(parts, source, destinationAndHost)
+
+	cmd := exec.Command("scp", parts...)
 
 	data, err := cmd.CombinedOutput()
 	if err != nil {


### PR DESCRIPTION
Warning warning warning: This also properly makes fatal errors fatal, despite them not being fatal before doing to fatal being left unset (this change is a prerequisite to making scp fail properly).

To test this, make sure to kill your ssh-agent, and then put invalid values for username and identity file in your ssh config, and then override both with env vars.

This fixes #22 