### PR TITLE
Extra functionality to enable use by provisioning tools

### DIFF
--- a/healthchecks/types.go
+++ b/healthchecks/types.go
@@ -20,7 +20,7 @@ type HealthChecks struct {
 }
 
 type CmdHealthCheck struct {
-	SshContext	*ssh.SSHContext
+	SshContext  *ssh.SSHContext
 	Description string
 	Cmd         []string
 	Period      int

--- a/morph.go
+++ b/morph.go
@@ -33,6 +33,7 @@ var (
 	timeout             int
 	askForSudoPasswd    bool
 	nixBuildArg         []string
+	nixBuildTargets     string
 	build               = buildCmd(app.Command("build", "Build machines"))
 	push                = pushCmd(app.Command("push", "Push machines"))
 	deploy              = deployCmd(app.Command("deploy", "Deploy machines"))
@@ -89,6 +90,12 @@ func nixBuildArgFlag(cmd *kingpin.CmdClause) {
 		StringsVar(&nixBuildArg)
 }
 
+func nixBuildTargetsFlag(cmd *kingpin.CmdClause) {
+	cmd.Flag("build-targets", "File containing a Nix attribute set defining build targets to use instead of the default").
+		HintFiles("nix").
+		ExistingFileVar(&nixBuildTargets)
+}
+
 func skipHealthChecksFlag(cmd *kingpin.CmdClause) {
 	cmd.
 		Flag("skip-health-checks", "Whether to skip all health checks").
@@ -99,6 +106,7 @@ func skipHealthChecksFlag(cmd *kingpin.CmdClause) {
 func buildCmd(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 	selectorFlags(cmd)
 	nixBuildArgFlag(cmd)
+	nixBuildTargetsFlag(cmd)
 	deploymentArg(cmd)
 	return cmd
 }
@@ -502,7 +510,7 @@ func buildHosts(hosts []nix.Host) (resultPath string, err error) {
 		return
 	}
 
-	resultPath, err = nix.BuildMachines(evalMachinesPath, deploymentPath, hosts, nixBuildArg)
+	resultPath, err = nix.BuildMachines(evalMachinesPath, deploymentPath, hosts, nixBuildArg, nixBuildTargets)
 	if err != nil {
 		return
 	}

--- a/nix/nix.go
+++ b/nix/nix.go
@@ -59,7 +59,7 @@ func GetMachines(evalMachines string, deploymentPath string) (hosts []Host, err 
 	return hosts, nil
 }
 
-func BuildMachines(evalMachines string, deploymentPath string, hosts []Host, nixArgs []string) (path string, err error) {
+func BuildMachines(evalMachines string, deploymentPath string, hosts []Host, nixArgs []string, nixBuildTargets string) (path string, err error) {
 	hostsArg := "["
 	for _, host := range hosts {
 		hostsArg += "\"" + host.TargetHost + "\" "
@@ -83,6 +83,11 @@ func BuildMachines(evalMachines string, deploymentPath string, hosts []Host, nix
 
 	if len(nixArgs) > 0 {
 		args = append(args, nixArgs...)
+	}
+
+	if nixBuildTargets != "" {
+		args = append(args,
+			"--arg", "buildTargets", fmt.Sprintf("import %s", nixBuildTargets))
 	}
 
 	cmd := exec.Command("nix-build", args...)

--- a/secrets/secrets.go
+++ b/secrets/secrets.go
@@ -14,7 +14,7 @@ type SecretError struct {
 
 func wrap(err error) *SecretError {
 	return &SecretError{
-		Err: err,
+		Err:   err,
 		Fatal: true,
 	}
 }


### PR DESCRIPTION
Specifically, this adds the following:
- A `list-secrets` subcommand that dumps the metadata for secrets for a deployment to stdout as JSON
- A `buildTargets` argument to the Nix machine builder expression, that expects an attribute set of the form `{ outputLinkName = node: node.config.some.attribute.to.build.per.machine; }` and replaces the default build targets based on this, if given
- A `--build-targets` `build` subcommand flag that just makes it more convenient to specify a file containing a valid `buildTargets` expression

This is something like the minimal set of extra functionality required for a provisioning tool to use Morph to handle generation of initial system images.

As an example of the kind of thing this would enable:
1. In a deployment, define a config attribute that builds a VMDK image of a node's initial state, as well as another that outputs a json file describing the resource requirements
2. `morph build some/deployment.nix --build-targets='./vm-image-target.nix' --on 'new-machine'` to build said attributes for a new machine
3. `morph list-secrets --on 'new-machine'` to get a JSON dump of the secrets metadata for that machine
4. Use the output from steps 2 and 3 to build a modified disk image with the secrets injected into it, and associate that with an OVF specifying the resource requirements, vm name, etc.
5. Push that off to some hypervisor platform for initial deployment
6. ...
7. Prophets?

-----

For a trivial example of an alternative build target:
`morph build some/deployment.nix --build-targets='./manual-epub.nix'`

Contents of `manual-epub.nix`:
```nix
{
  "manual" = node: node.config.system.build.manual.manualEpub;
}
```

-----

Some notes:
- Could also use `--build-targets` simply to let you store configuration for things like ISOs or PXE-bootable images in the same location and format as managed deployments, and build them through Morph as well
- I'm not particularly familiar with Go
- I think these are low-level enough to potentially be used for a variety of different purposes, not just building initial system images, but that is the one I care about