### PR TITLE
Control the value of morph --version output via ldflags

### DIFF
--- a/morph.go
+++ b/morph.go
@@ -18,10 +18,12 @@ import (
 	"syscall"
 )
 
+// This is set at build time via -ldflags magic
+var version string
 var switchActions = []string{"dry-activate", "test", "switch", "boot"}
 
 var (
-	app                 = kingpin.New("morph", "NixOS host manager").Version("1.0")
+	app                 = kingpin.New("morph", "NixOS host manager").Version(version)
 	dryRun              = app.Flag("dry-run", "Don't do anything, just eval and print changes").Default("False").Bool()
 	selectGlob          string
 	selectEvery         int

--- a/nix-packaging/default.nix
+++ b/nix-packaging/default.nix
@@ -23,6 +23,12 @@ buildGoPackage rec {
   src = filterSource srcFilter ./..;
   goDeps = ./deps.nix;
 
+  buildFlagsArray = ''
+    -ldflags=
+    -X
+    main.version=${version}
+  '';
+
   prePatch = ''
     go-bindata -pkg assets -o assets/assets.go data/
   '';


### PR DESCRIPTION
Using _ldflags to variable_ Golang linker magic, we can inject the morph version parameter at build time, which - in any case - is better than the current hardcoding of `1.0`.