### PR TITLE
Add list-secrets subcommand

### DIFF
--- a/healthchecks/types.go
+++ b/healthchecks/types.go
@@ -20,7 +20,7 @@ type HealthChecks struct {
 }
 
 type CmdHealthCheck struct {
-	SshContext	*ssh.SSHContext
+	SshContext  *ssh.SSHContext
 	Description string
 	Cmd         []string
 	Period      int

--- a/secrets/secrets.go
+++ b/secrets/secrets.go
@@ -14,7 +14,7 @@ type SecretError struct {
 
 func wrap(err error) *SecretError {
 	return &SecretError{
-		Err: err,
+		Err:   err,
 		Fatal: true,
 	}
 }

--- a/secrets/types.go
+++ b/secrets/types.go
@@ -1,5 +1,8 @@
 package secrets
 
+import "fmt"
+import "strings"
+
 type Secret struct {
 	Source      string
 	Destination string
@@ -12,4 +15,17 @@ type Secret struct {
 type Owner struct {
 	Group string
 	User  string
+}
+
+func (s *Secret) String() string {
+	var string_repr strings.Builder
+
+	fmt.Fprintf(&string_repr, "`%s` -> `%s`, with:\n\tPermissions: %s:%s, %s\n\tCreate remote directories: %t",
+		s.Source, s.Destination, s.Owner.User, s.Owner.Group, s.Permissions, s.MkDirs)
+
+	if len(s.Action) > 0 {
+		fmt.Fprintf(&string_repr, "\n\tAction: `%s`", strings.Join(s.Action, " "))
+	}
+
+	return string_repr.String()
 }


### PR DESCRIPTION
Split off from #35.

Adds a `list-secrets` subcommand that outputs the metadata for secrets for a deployment to stdout as plain text, or as JSON.