### PR TITLE
Add build target/target-file flags to build subcommand

### DIFF
--- a/morph.go
+++ b/morph.go
@@ -33,6 +33,7 @@ var (
 	timeout             int
 	askForSudoPasswd    bool
 	nixBuildArg         []string
+	nixBuildTargetFile  string
 	build               = buildCmd(app.Command("build", "Build machines"))
 	push                = pushCmd(app.Command("push", "Push machines"))
 	deploy              = deployCmd(app.Command("deploy", "Deploy machines"))
@@ -88,6 +89,12 @@ func nixBuildArgFlag(cmd *kingpin.CmdClause) {
 		StringsVar(&nixBuildArg)
 }
 
+func nixBuildTargetFileFlag(cmd *kingpin.CmdClause) {
+	cmd.Flag("target-file", "File containing a Nix attribute set, defining build targets to use instead of the default").
+		HintFiles("nix").
+		ExistingFileVar(&nixBuildTargetFile)
+}
+
 func skipHealthChecksFlag(cmd *kingpin.CmdClause) {
 	cmd.
 		Flag("skip-health-checks", "Whether to skip all health checks").
@@ -98,6 +105,7 @@ func skipHealthChecksFlag(cmd *kingpin.CmdClause) {
 func buildCmd(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 	selectorFlags(cmd)
 	nixBuildArgFlag(cmd)
+	nixBuildTargetFileFlag(cmd)
 	deploymentArg(cmd)
 	return cmd
 }
@@ -464,7 +472,13 @@ func buildHosts(hosts []nix.Host) (resultPath string, err error) {
 		return
 	}
 
-	resultPath, err = nix.BuildMachines(evalMachinesPath, deploymentPath, hosts, nixBuildArg)
+	nixBuildTargets := ""
+	if nixBuildTargetFile != "" {
+		if path, err := filepath.Abs(nixBuildTargetFile); err == nil {
+			nixBuildTargets = fmt.Sprintf("import \"%s\"", path)
+		}
+	}
+	resultPath, err = nix.BuildMachines(evalMachinesPath, deploymentPath, hosts, nixBuildArg, nixBuildTargets)
 	if err != nil {
 		return
 	}

--- a/nix/nix.go
+++ b/nix/nix.go
@@ -59,7 +59,7 @@ func GetMachines(evalMachines string, deploymentPath string) (hosts []Host, err 
 	return hosts, nil
 }
 
-func BuildMachines(evalMachines string, deploymentPath string, hosts []Host, nixArgs []string) (path string, err error) {
+func BuildMachines(evalMachines string, deploymentPath string, hosts []Host, nixArgs []string, nixBuildTargets string) (path string, err error) {
 	hostsArg := "["
 	for _, host := range hosts {
 		hostsArg += "\"" + host.TargetHost + "\" "
@@ -83,6 +83,11 @@ func BuildMachines(evalMachines string, deploymentPath string, hosts []Host, nix
 
 	if len(nixArgs) > 0 {
 		args = append(args, nixArgs...)
+	}
+
+	if nixBuildTargets != "" {
+		args = append(args,
+			"--arg", "buildTargets", nixBuildTargets)
 	}
 
 	cmd := exec.Command("nix-build", args...)


### PR DESCRIPTION
Split off from #35.

Adds:
- A `buildTargets` argument to the Nix machine builder expression, that expects an attribute set of the form `{ outputLinkName = node: node.config.some.attribute.to.build.per.machine; }` and replaces the default build targets based on this, if given
- A `--target` flag on `morph build` that allows specifying a single `buildTargets` set member on the CLI as a lambda, e.g. `morph build some/deployment.nix --target 'node: node.config.environment.etc."nix/nix.conf"'`
- A `--target-file` flag on `morph build` that makes it convenient to specify a file to import containing a valid `buildTargets` expression, e.g. `morph build some/deployment.nix --build-targets='./manual-epub.nix'`

  Where the contents of `manual-epub.nix` are:
  ```nix
  {
    "manual" = node: node.config.system.build.manual.manualEpub;
  }
  ```