### PR TITLE
Show trace flag

### DIFF
--- a/morph.go
+++ b/morph.go
@@ -42,7 +42,7 @@ var (
 	deployUploadSecrets bool
 	deployReboot        bool
 	skipHealthChecks    bool
-	showTrace			bool
+	showTrace           bool
 	healthCheck         = healthCheckCmd(app.Command("check-health", "Run health checks"))
 	uploadSecrets       = uploadSecretsCmd(app.Command("upload-secrets", "Upload secrets"))
 	listSecrets         = listSecretsCmd(app.Command("list-secrets", "List secrets"))
@@ -539,7 +539,7 @@ func getHosts(deploymentFile string) (hosts []nix.Host, err error) {
 func getNixContext() *nix.NixContext {
 	return &nix.NixContext{
 		EvalMachines: filepath.Join(assetRoot, "eval-machines.nix"),
-		ShowTrace: showTrace,
+		ShowTrace:    showTrace,
 	}
 }
 

--- a/nix/nix.go
+++ b/nix/nix.go
@@ -25,7 +25,7 @@ type Host struct {
 
 type NixContext struct {
 	EvalMachines string
-	ShowTrace bool
+	ShowTrace    bool
 }
 
 func (host *Host) GetTargetHost() string {


### PR DESCRIPTION
## Added --show-trace flag to morph

- Put eval-machines path and show trace option in a new struct called
NixContext for the purpose of minimising the number of flags we need to
pass to nix.GetMachines() and nix.BuildMachines() respectively.

- Deprecated the `--build-arg` flag, because.. it was introduced pretty
much only to be able to pass `--show-trace`, and it only works on "nix
build" anyway (not eval) with a lot of existing limitations.

fixes #44