### PR TITLE
Implement timeouts for command based health checks

### DIFF
--- a/ssh/ssh.go
+++ b/ssh/ssh.go
@@ -2,6 +2,7 @@ package ssh
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"golang.org/x/crypto/ssh/terminal"
@@ -45,7 +46,11 @@ type FileTransfer struct {
 	Destination string
 }
 
-func (ctx *SSHContext) Cmd(host Host, parts ...string) (*exec.Cmd, error) {
+func (sshCtx *SSHContext) Cmd(host Host, parts ...string) (*exec.Cmd, error) {
+	return sshCtx.CmdContext(context.TODO(), host, parts...)
+}
+
+func (sshCtx *SSHContext) CmdContext(ctx context.Context, host Host, parts ...string) (*exec.Cmd, error) {
 
 	var err error
 	if parts, err = valCommand(parts); err != nil {
@@ -53,13 +58,13 @@ func (ctx *SSHContext) Cmd(host Host, parts ...string) (*exec.Cmd, error) {
 	}
 
 	if parts[0] == "sudo" {
-		return ctx.SudoCmd(host, parts...)
+		return sshCtx.SudoCmdContext(ctx, host, parts...)
 	}
 
-	cmd, cmdArgs := ctx.sshArgs(host, nil)
+	cmd, cmdArgs := sshCtx.sshArgs(host, nil)
 	cmdArgs = append(cmdArgs, parts...)
 
-	command := exec.Command(cmd, cmdArgs...)
+	command := exec.CommandContext(ctx, cmd, cmdArgs...)
 	return command, nil
 }
 
@@ -93,21 +98,25 @@ func (ctx *SSHContext) sshArgs(host Host, transfer *FileTransfer) (cmd string, a
 	return
 }
 
-func (ctx *SSHContext) SudoCmd(host Host, parts ...string) (*exec.Cmd, error) {
+func (sshCtx *SSHContext) SudoCmd(host Host, parts ...string) (*exec.Cmd, error) {
+	return sshCtx.SudoCmdContext(context.TODO(), host, parts...)
+}
+
+func (sshCtx *SSHContext) SudoCmdContext(ctx context.Context, host Host, parts ...string) (*exec.Cmd, error) {
 	var err error
 	if parts, err = valCommand(parts); err != nil {
 		return nil, err
 	}
 
 	// ask for password if not done already
-	if ctx.AskForSudoPassword && ctx.sudoPassword == "" {
-		ctx.sudoPassword, err = askForSudoPassword()
+	if sshCtx.AskForSudoPassword && sshCtx.sudoPassword == "" {
+		sshCtx.sudoPassword, err = askForSudoPassword()
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	cmd, cmdArgs := ctx.sshArgs(host, nil)
+	cmd, cmdArgs := sshCtx.sshArgs(host, nil)
 
 	// normalize sudo
 	if parts[0] == "sudo" {
@@ -115,7 +124,7 @@ func (ctx *SSHContext) SudoCmd(host Host, parts ...string) (*exec.Cmd, error) {
 	}
 	cmdArgs = append(cmdArgs, "sudo")
 
-	if ctx.sudoPassword != "" {
+	if sshCtx.sudoPassword != "" {
 		cmdArgs = append(cmdArgs, "-S")
 	} else {
 		// no password supplied; request non-interactive sudo, which will fail with an error if a password was required
@@ -125,9 +134,9 @@ func (ctx *SSHContext) SudoCmd(host Host, parts ...string) (*exec.Cmd, error) {
 	cmdArgs = append(cmdArgs, "-p", "''", "-k", "--")
 	cmdArgs = append(cmdArgs, parts...)
 
-	command := exec.Command(cmd, cmdArgs...)
-	if ctx.sudoPassword != "" {
-		err := writeSudoPassword(command, ctx.sudoPassword)
+	command := exec.CommandContext(ctx, cmd, cmdArgs...)
+	if sshCtx.sudoPassword != "" {
+		err := writeSudoPassword(command, sshCtx.sudoPassword)
 		if err != nil {
 			return nil, err
 		}

--- a/ssh/ssh.go
+++ b/ssh/ssh.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/dbcdk/morph/utils"
 	"golang.org/x/crypto/ssh/terminal"
 	"io"
 	"os"
@@ -12,7 +13,6 @@ import (
 	"path/filepath"
 	"strings"
 	"syscall"
-	"time"
 )
 
 type Context interface {
@@ -154,7 +154,7 @@ func valCommand(parts []string) ([]string, error) {
 }
 
 func (sshCtx *SSHContext) CmdInteractive(host Host, timeout int, parts ...string) {
-	ctx, cancel := context.WithTimeout(context.TODO(), time.Duration(timeout)*time.Second)
+	ctx, cancel := utils.ContextWithConditionalTimeout(context.TODO(), timeout)
 	defer cancel()
 
 	cmd, err := sshCtx.CmdContext(ctx, host, parts...)

--- a/utils/context.go
+++ b/utils/context.go
@@ -1,0 +1,22 @@
+package utils
+
+import (
+	"context"
+	"time"
+)
+
+// Create a context with a timeout, but only if the timeout is longer than 0
+func ContextWithConditionalTimeout(parent context.Context, timeout int) (context.Context, context.CancelFunc) {
+	var (
+		ctx context.Context
+		cancel context.CancelFunc
+	)
+
+	if timeout <= 0 {
+		ctx, cancel = context.WithCancel(context.TODO())
+	} else {
+		ctx, cancel = context.WithTimeout(context.TODO(), time.Duration(timeout)*time.Second)
+	}
+
+	return ctx, cancel
+}


### PR DESCRIPTION
This introduces `context.Context` in a few places, most importantly in the new context-aware versions of `ssh.Cmd` and `ssh.SudoCmd`. This is used by the cmd-based health checks to ensure enforcement of timeouts.

Furthermore, `ssh.CmdInteractive` has been rewritten to use contexts, instead of manually creating channels and goroutines to monitor kill the process. There was nothing wrong with the current implementation, but using the built in primitives should be safer and easier to reason about, and now it's handled in the same manner as timeouts in the new versions of `ssh.Cmd` and `ssh.SudoCmd`

Fixes #40, fixes #43 


Notes:
`context.TODO()` is using to acknowledge the lack of a parent context that hasn't been implemented yet. Depending on the future work, the `context.Background()` version might be more correct. In practice it shouldn't do any difference for us now. None of the contexts created in this way can be cancelled.



Output from `morph switch foo boot --reboot` (which never terminated before):
```
Asking host to reboot ... 
Running healthchecks on dhcp160-p01:
	* Ask systemd whether there are failed or queued units.: Failed (Health check error: Failed to connect to bus: Broken pipe
Failed to connect to bus: Broken pipe
)
	* Test DHCP request using /nix/store/yn5f1nysfafvkzdmmf6276axdgh4b611-check-dhcp: Failed (Health check error: Timeout after 5s)
	* Ask systemd whether there are failed or queued units.: Failed (Health check error: Timeout after 5s)
	* Test DHCP request using /nix/store/yn5f1nysfafvkzdmmf6276axdgh4b611-check-dhcp: Failed (Health check error: Timeout after 5s)
	* Ask systemd whether there are failed or queued units.: Failed (Health check error: Timeout after 5s)
	* Test DHCP request using /nix/store/yn5f1nysfafvkzdmmf6276axdgh4b611-check-dhcp: Failed (Health check error: Timeout after 5s)
	* Ask systemd whether there are failed or queued units.: Failed (Health check error: Timeout after 5s)
	* Test DHCP request using /nix/store/yn5f1nysfafvkzdmmf6276axdgh4b611-check-dhcp: OK
	* Ask systemd whether there are failed or queued units.: OK
Health checks OK
Done: dhcp160-p01
```
Notice that we actually get useful error messages on timeouts.

Morph exec has the exact same output as well. No timeout:
```
Selected 1/8 hosts (name filter:-0, limits:-7):
	  0: dhcp160-p01 (secrets: 0, health checks: 2)

** dhcp160-p01
foo
```

Timeout:
```
Selected 1/8 hosts (name filter:-0, limits:-7):
	  0: dhcp160-p01 (secrets: 0, health checks: 2)

** dhcp160-p01
Exec of cmd: [sleep 10] timed out
```