### PR TITLE
delay health checks until host has finished rebooting

### DIFF
--- a/nix/nix.go
+++ b/nix/nix.go
@@ -12,6 +12,8 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"syscall"
+	"time"
 )
 
 type Host struct {
@@ -34,6 +36,66 @@ func (host *Host) GetTargetHost() string {
 
 func (host *Host) GetHealthChecks() healthchecks.HealthChecks {
 	return host.HealthChecks
+}
+
+func (host *Host) Reboot(sshContext *ssh.SSHContext) error {
+
+	var (
+		oldBootID string
+		newBootID string
+	)
+
+	oldBootID, err := sshContext.GetBootID(host)
+	// If the host doesn't support getting boot ID's for some reason, warn about it, and skip the comparison
+	skipBootIDComparison := err != nil
+	if skipBootIDComparison {
+		fmt.Fprintf(os.Stderr, "Error getting boot ID (this is used to determine when the reboot is complete): %v\n", err)
+		fmt.Fprintf(os.Stderr, "This makes it impossible to detect when the host has rebooted, so health checks might pass before the host has rebooted.\n")
+	}
+
+	if cmd, err := sshContext.Cmd(host, "sudo", "reboot"); cmd != nil {
+		fmt.Fprint(os.Stderr, "Asking host to reboot ... ")
+		if err = cmd.Run(); err != nil {
+			// Here we assume that exit code 255 means: "SSH connection got disconnected",
+			// which is OK for a reboot - sshd may close active connections before we disconnect after all
+			if exitErr, ok := err.(*exec.ExitError); ok {
+				if status, ok := exitErr.Sys().(syscall.WaitStatus); ok && status.ExitStatus() == 255 {
+					fmt.Fprintln(os.Stderr, "Remote host disconnected.")
+					err = nil
+				}
+			}
+		}
+
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "Failed")
+			return err
+		}
+	}
+
+	fmt.Fprintln(os.Stderr, "OK")
+
+	if !skipBootIDComparison {
+		fmt.Fprint(os.Stderr, "Waiting for host to come online ")
+
+		// Wait for the host to get a new boot ID. These ID's should be unique for each boot,
+		// meaning a reboot will have been completed when the boot ID has changed.
+		for {
+			fmt.Fprint(os.Stderr, ".")
+
+			// Ignore errors; there'll be plenty of them since we'll be attempting to connect to an offline host,
+			// and we know from previously that the host should support boot ID's
+			newBootID, _ = sshContext.GetBootID(host)
+
+			if newBootID != "" && oldBootID != newBootID {
+				fmt.Fprintln(os.Stderr, " OK")
+				break
+			}
+
+			time.Sleep(2 * time.Second)
+		}
+	}
+
+	return nil
 }
 
 func (ctx *NixContext) GetMachines(deploymentPath string) (hosts []Host, err error) {


### PR DESCRIPTION
This is implemented by getting the current boot ID, triggering reboot,
and then delaying health checks until the boot ID has changed.

Fixes #47