### PR TITLE
nix-build: Option to keep latest build result around to prevent GC

### DIFF
--- a/morph.go
+++ b/morph.go
@@ -53,6 +53,7 @@ var (
 
 	tempDir, tempDirErr  = ioutil.TempDir("", "morph-")
 	assetRoot, assetsErr = assets.Setup()
+	keepGCRoot           = *app.Flag("keep-result", "Keep latest build in .gcroots to prevent it from being garbage collected").Default("True").Bool()
 )
 
 func deploymentArg(cmd *kingpin.CmdClause) {
@@ -540,6 +541,7 @@ func getNixContext() *nix.NixContext {
 	return &nix.NixContext{
 		EvalMachines: filepath.Join(assetRoot, "eval-machines.nix"),
 		ShowTrace:    showTrace,
+		KeepGCRoot:   keepGCRoot,
 	}
 }
 


### PR DESCRIPTION
Having results in /tmp leaves symlinks dangling pretty much immediately