### PR TITLE
Prevent morph to deploy onto a remote machine by temporarily touching a file

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,10 @@ Health checks will be repeated until success, and the interval can be configured
 
 It is currently possible to have expressions like `"test \"$(systemctl list-units --failed --no-legend --no-pager |wc -l)\" -eq 0"` (count number of failed systemd units, fail if non-zero) as the first argument in a cmd-healthcheck. This works, but is discouraged, and might break at any time.
 
+## Disabling morph
+
+In case you need to prevent morph to deploy onto system temporarily, just touch the /.morph_condor file.
+
 
 ## Hacking morph
 

--- a/ssh/ssh.go
+++ b/ssh/ssh.go
@@ -213,6 +213,13 @@ func (ctx *SSHContext) ActivateConfiguration(host Host, configuration string, ac
 		}
 	}
 
+	condor := ctx.HostCondor(host)
+	if condor == nil {
+		fmt.Fprintln(os.Stderr, "Morph is disabled on the remote host (/.morph_condor).")
+		return nil
+	}
+
+
 	args := []string{filepath.Join(configuration, "bin/switch-to-configuration"), action}
 
 	var (
@@ -235,6 +242,20 @@ func (ctx *SSHContext) ActivateConfiguration(host Host, configuration string, ac
 		return errors.New("Error while activating new configuration.")
 	}
 
+	return nil
+}
+
+func (ctx *SSHContext) HostCondor(host Host) error {
+
+	cmd, err := ctx.Cmd(host, "test", "-f", "/.morph_condor")
+
+	cmd.Stdout = os.Stderr
+	cmd.Stderr = os.Stderr
+	err = cmd.Run()
+
+	if err != nil {
+		return err
+	}
 	return nil
 }
 


### PR DESCRIPTION
From time to time, when working temporarily on a machine, I need to ensure morph doesn't deploy under me. This features will prevent to deploy in case the file _/.morph_disabled_ exists on the remote host.