### PR TITLE
Merge per-machine nixpkgs arguments on top of network-wide ones

### DIFF
--- a/data/eval-machines.nix
+++ b/data/eval-machines.nix
@@ -32,7 +32,7 @@ rec {
                 deployment.targetHost = lib.mkDefault machineName;
 
                 # Apply network-level nixpkgs arguments as a baseline for
-                # per-machine nixpkgs arguments; set at 900 priority so they
+                # per-machine nixpkgs arguments; mkDefault'ed so they
                 # can be overridden from within each machine
                 nixpkgs.localSystem = lib.mkDefault pkgs.buildPlatform;
                 nixpkgs.crossSystem = lib.mkDefault pkgs.hostPlatform;


### PR DESCRIPTION
Fixes #34. Got around to looking through nixpkgs eval mechanism again, now having more experience messing with it, and this appears to work nearly perfectly. The only thing it will not handle correctly is `nixpkgs.system`, but as is documented in the nixpkgs manual, you should instead set `nixpkgs.localSystem.system`.

Test deployment to see the impact:
`test.nix`:
```nix
let
  pkgs = import <nixpkgs> {
    config.allowUnfree = true;
    overlays = [ (self: super: {}) ];
  };

  common = { name, config, pkgs, ... }: {
    system.activationScripts.testingOverlays = ''
      # ${builtins.trace "machine: ${name}" "nak"}
      # ${builtins.trace config.nixpkgs.overlays "nak"}
      # ${builtins.trace config.nixpkgs.localSystem.system "nak"}
      # ${builtins.trace config.nixpkgs.crossSystem.system "nak"}
      # ${pkgs.lib.traceSeq pkgs.config "nak"}
    '';
    fileSystems."/" = { label = "root"; fsType = "ext4"; };
    boot.loader.grub.device = "/dev/sda";
  };
in
{
  network = {
    inherit pkgs;
    description = "Example nixpkgs argument merging successes";
  };

  "with-config" = { config, lib, pkgs, ... }: {
    imports = [ common ];
    nixpkgs.config.allowBroken = true;
  };
  "overridden-config" = { config, lib, pkgs, ...}: {
    imports = [ common ];
    nixpkgs.config.allowUnfree = false;
  };
  "with-overlays" = { config, lib, pkgs, ...}: {
    imports = [ common ];
    nixpkgs.overlays = [
      (self: super: {
        pam_mount = super.pam_mount.overrideAttrs(oldAttrs: {
          name = "pam_mount overidden by overlay";
        });
      })
    ];
  };
  "with-localsystem" = { config, lib, pkgs, ...}: {
    imports = [ common ];
    nixpkgs.localSystem.system = "aarch64-linux";
  };
  "with-crosssystem" = { config, lib, pkgs, ...}: {
    imports = [ common ];
    nixpkgs.crossSystem.system = "aarch64-linux";
  };
  "with-pkgs" = { config, lib, pkgs, ...}: {
    imports = [ common ];
    nixpkgs.pkgs = import <nixpkgs> { };
  };
}
```
```sh
$ morph build --dry-run test.nix
Selected 6/6 hosts (name filter:-0, limits:-0):
          0: overridden-config (secrets: 0, health checks: 0)
          1: with-config (secrets: 0, health checks: 0)
          2: with-crosssystem (secrets: 0, health checks: 0)
          3: with-localsystem (secrets: 0, health checks: 0)
          4: with-overlays (secrets: 0, health checks: 0)
          5: with-pkgs (secrets: 0, health checks: 0)

trace: machine: overridden-config
trace: [ <LAMBDA> ]
trace: x86_64-linux
trace: x86_64-linux
trace: { allowUnfree = false; doCheckByDefault = false; warnings = [ ]; }
trace: machine: with-config
trace: [ <LAMBDA> ]
trace: x86_64-linux
trace: x86_64-linux
trace: { allowBroken = true; allowUnfree = true; doCheckByDefault = false; warnings = [ ]; }
trace: machine: with-crosssystem
trace: [ <LAMBDA> ]
trace: x86_64-linux
trace: aarch64-linux
trace: { allowUnfree = true; doCheckByDefault = false; warnings = [ ]; }
trace: machine: with-localsystem
trace: [ <LAMBDA> ]
trace: aarch64-linux
trace: x86_64-linux
trace: { allowUnfree = true; doCheckByDefault = false; warnings = [ ]; }
trace: machine: with-overlays
trace: [ <LAMBDA> ]
trace: x86_64-linux
trace: x86_64-linux
trace: { allowUnfree = true; doCheckByDefault = false; warnings = [ ]; }
trace: machine: with-pkgs
trace: [ <LAMBDA> ]
trace: x86_64-linux
trace: x86_64-linux
trace: { doCheckByDefault = false; warnings = [ ]; }
```