### PR TITLE
Workaround/fix for issue #68

### DIFF
--- a/data/eval-machines.nix
+++ b/data/eval-machines.nix
@@ -37,12 +37,16 @@ rec {
                 nixpkgs.localSystem = lib.mkDefault pkgs.buildPlatform;
                 nixpkgs.crossSystem = lib.mkDefault pkgs.hostPlatform;
                 nixpkgs.overlays = lib.mkDefault pkgs.overlays;
-                nixpkgs.pkgs = lib.mkDefault (import pkgs.path {
-                  inherit (config.nixpkgs) overlays localSystem crossSystem;
+                nixpkgs.pkgs = lib.mkDefault (import pkgs.path ({
+                  inherit (config.nixpkgs) overlays localSystem;
                   # Merge nixpkgs.config using its merge function
                   config = options.nixpkgs.config.type.merge ""
                     ([ { value = pkgs.config; } options.nixpkgs.config ]);
-                });
+                } // lib.optionalAttrs (config.nixpkgs.localSystem != config.nixpkgs.crossSystem) {
+                  # Only override crossSystem if it is not equivalent to
+                  # localSystem; works around issue #68
+                  inherit (config.nixpkgs) crossSystem;
+                }));
               })
             ];
           extraArgs = { inherit nodes ; name = machineName; };


### PR DESCRIPTION
Closes #68, but I think probably upstream nixpkgs should also be changed -- ideally, I think both `pkgsMusl` and `pkgsi686Linux` should explicitly set *both* `localSystem` and `crossSystem` in the `stdenv.hostPlatform == stdenv.buildPlatform` case, rather than relying on the behaviour around default/`null` `crossSystem` arguments to nixpkgs.