### PR TITLE
Don't apply overlays twice

### DIFF
--- a/data/eval-machines.nix
+++ b/data/eval-machines.nix
@@ -38,7 +38,7 @@ rec {
                 nixpkgs.crossSystem = lib.mkDefault pkgs.hostPlatform;
                 nixpkgs.overlays = lib.mkDefault pkgs.overlays;
                 nixpkgs.pkgs = lib.mkDefault (import pkgs.path ({
-                  inherit (config.nixpkgs) overlays localSystem;
+                  inherit (config.nixpkgs) localSystem;
                   # Merge nixpkgs.config using its merge function
                   config = options.nixpkgs.config.type.merge ""
                     ([ { value = pkgs.config; } options.nixpkgs.config ]);


### PR DESCRIPTION
fixes #71

Thanks for reporting @delroth! I actually thought about this when merging #67, but I guess I was too confident to test it at that time :)

While localSystem and crossSystem are merged without issues, overlays are appended. This causes the overlay to be applied twice.

I used this for testing:
```
let
  # Pin the deployment package-set to a specific version of nixpkgs
  _pkgs = pargs: import (builtins.fetchTarball {
    url = "https://github.com/NixOS/nixpkgs/archive/98d9589819218971a95fd64c172fe5996a9734f5.tar.gz";
    sha256 = "0blscxj13qbcnlxkzwjsyqa80ssnx9wm0wz0bg6gkc1fa412w4f9";
  }) pargs;

  overlay = (self: super: {
    my_hello = if super?my_hello then throw "fail" else super.hello;
  });

  common = { pkgs, ... }: {
    boot.loader.systemd-boot.enable = true;
    boot.loader.efi.canTouchEfiVariables = true;

    environment.systemPackages = with pkgs; [ my_hello ];

    fileSystems = {
        "/" = { label = "nixos"; fsType = "ext4"; };
        "/boot" = { label = "boot"; fsType = "vfat"; };
    };
  };
in
{
  network =  {
    pkgs = _pkgs {};
    description = "simple hosts";
  };

  asConfigOption = builtins.trace "asConfigOption" ({ ... }: {

    imports = [common];

    nixpkgs.overlays = [overlay];

  });

  asPkgsArg = builtins.trace "asPkgsArg" ({ config, pkgs, ... }: {

    imports = [common];

    nixpkgs.pkgs = _pkgs {
      overlays = [overlay];
    };

  });

  both = builtins.trace "both" ({ ... }: {

    imports = [common];

    nixpkgs.overlays = [overlay];

    nixpkgs.pkgs = _pkgs {
      overlays = [overlay];
    };

  });
}
```

I hope both of you would agree it's ok that "both" fail this test? I've sort of asked for it.

cc @delroth @Shados 