### PR TITLE
push: try to use the targets binary caches

### DIFF
--- a/nix/nix.go
+++ b/nix/nix.go
@@ -241,6 +241,7 @@ func Push(ctx *ssh.SSHContext, host Host, paths ...string) (err error) {
 	for _, path := range paths {
 		cmd := exec.Command(
 			"nix", "copy",
+			"--substitute-on-destination",
 			path,
 			"--to", "ssh://"+userArg+host.TargetHost+keyArg,
 		)


### PR DESCRIPTION
By allowing the remote to substitute using the configured binary caches
(e.g. https://cache.nixos.org) you have to upload a lot less data to the
remote host. This improves the user experience on some residential
connections that sadly still have miserable upload performance. Even
worse is the situation on metered connections where the user might have
to pay for each megabyte of data.

Nix copy will ask the remote store to try to fulfill a list of
transmitted paths and only those that can not be provided by any of the
registered binary caches will be uploaded from the local machine.

There is no real downside to this. It might take a few seconds to verify
if a specific path can be downloaded from a binary cache. That time is
probably not significant when compared to uploading an entire system
closure from a slow (or metered) connection.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dbcdk/morph/73)
<!-- Reviewable:end -->
