### PR TITLE
Run `deploy dry-activate` with sudo

### DIFF
--- a/ssh/ssh.go
+++ b/ssh/ssh.go
@@ -219,11 +219,7 @@ func (ctx *SSHContext) ActivateConfiguration(host Host, configuration string, ac
 		cmd *exec.Cmd
 		err error
 	)
-	if action == "dry-activate" {
-		cmd, err = ctx.Cmd(host, args...)
-	} else {
-		cmd, err = ctx.SudoCmd(host, args...)
-	}
+	cmd, err = ctx.SudoCmd(host, args...)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
It is really not possible to get a sane dry-activate output without being root. The `switch-to-configuration` script yields _would restart systemd_, which is not true, and it is caused by an underlying permission denied error.
