### PR TITLE
Configurable nix options and substitute-on-destination

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,8 +163,10 @@ The default is an empty set, meaning that the nix configuration is inherited fro
 
 `buildOnly` makes morph skip the "push" and "switch" steps for the given host, even if "morph deploy" or "morph push" is executed. (default: false)
 
+`substituteOnDestination` Sets the `--substitute-on-destination` flag on nix copy, allowing for the deployment target to use substitutes. See `nix copy --help`. (default: false)
 
-Example usage of `nixConfig` and `deployment.buildOnly`:
+
+Example usage of `nixConfig` and deployment module options:
 ```
 network = {
     nixConfig = {
@@ -176,6 +178,9 @@ machine1 = { ... }: {
     deployment.buildOnly = true;
 };
 
+machine2 = { ... }: {
+    deployment.substituteOnDestination = true;
+};
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -151,6 +151,33 @@ Health checks will be repeated until success, and the interval can be configured
 
 It is currently possible to have expressions like `"test \"$(systemctl list-units --failed --no-legend --no-pager |wc -l)\" -eq 0"` (count number of failed systemd units, fail if non-zero) as the first argument in a cmd-healthcheck. This works, but is discouraged, and might break at any time.
 
+### Advanced configuration
+
+**nix.conf-options:** The "network"-attrset supports a sub-attrset named "nixConfig". Options configured here will pass `--option <name> <value>` to all nix commands.
+Note: these options apply to an entire deployment and are *not* configurable on per-host basis.
+The default is an empty set, meaning that the nix configuration is inherited from the build environment. See `man nix.conf`.
+
+**special deployment options:**
+
+(per-host granularity)
+
+`buildOnly` makes morph skip the "push" and "switch" steps for the given host, even if "morph deploy" or "morph push" is executed. (default: false)
+
+
+Example usage of `nixConfig` and `deployment.buildOnly`:
+```
+network = {
+    nixConfig = {
+        "extra-sandbox-paths" = "/foo/bar";
+    };
+};
+
+machine1 = { ... }: {
+    deployment.buildOnly = true;
+};
+
+```
+
 
 ## Hacking morph
 

--- a/data/eval-machines.nix
+++ b/data/eval-machines.nix
@@ -72,7 +72,7 @@ rec {
 
     machines =
       flip mapAttrs nodes (n: v': let v = scrubOptionValue v'; in
-        { inherit (v.config.deployment) targetHost secrets healthChecks buildOnly;
+        { inherit (v.config.deployment) targetHost secrets healthChecks buildOnly substituteOnDestination;
           name = n;
           nixosRelease = v.config.system.nixos.release or (removeSuffix v.config.system.nixos.version.suffix v.config.system.nixos.version);
           nixConfig = mapAttrs

--- a/data/eval-machines.nix
+++ b/data/eval-machines.nix
@@ -75,6 +75,9 @@ rec {
         { inherit (v.config.deployment) targetHost secrets healthChecks buildOnly;
           name = n;
           nixosRelease = v.config.system.nixos.release or (removeSuffix v.config.system.nixos.version.suffix v.config.system.nixos.version);
+          nixConfig = mapAttrs
+            (n: v: if builtins.isString v then v else throw "nix option '${n}' must have a string typed value")
+            (network'.network.nixConfig or {});
         }
       );
 

--- a/data/options.nix
+++ b/data/options.nix
@@ -172,6 +172,16 @@ in
       '';
     };
 
+    substituteOnDestination = mkOption {
+      type = bool;
+      default = false;
+      description = ''
+        Sets the `--substitute-on-destination` flag on nix copy,
+        allowing for the deployment target to use substitutes.
+        See `nix copy --help`.
+      '';
+    };
+
     secrets = mkOption {
       default = {};
       example = {

--- a/nix/nix.go
+++ b/nix/nix.go
@@ -24,6 +24,7 @@ type Host struct {
 	TargetHost   string
 	Secrets      map[string]secrets.Secret
 	BuildOnly    bool
+	SubstituteOnDestination bool
 	NixConfig    map[string]string
 }
 
@@ -259,6 +260,9 @@ func Push(ctx *ssh.SSHContext, host Host, paths ...string) (err error) {
 			"--to", "ssh://" + userArg + host.TargetHost + keyArg,
 		}
 		args = append(args, options...)
+		if host.SubstituteOnDestination {
+			args = append(args, "--substitute-on-destination")
+		}
 
 		cmd := exec.Command(
 			"nix", args...,

--- a/nix/nix.go
+++ b/nix/nix.go
@@ -11,21 +11,21 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"syscall"
 	"time"
-	"path"
 )
 
 type Host struct {
-	HealthChecks healthchecks.HealthChecks
-	Name         string
-	NixosRelease string
-	TargetHost   string
-	Secrets      map[string]secrets.Secret
-	BuildOnly    bool
+	HealthChecks            healthchecks.HealthChecks
+	Name                    string
+	NixosRelease            string
+	TargetHost              string
+	Secrets                 map[string]secrets.Secret
+	BuildOnly               bool
 	SubstituteOnDestination bool
-	NixConfig    map[string]string
+	NixConfig               map[string]string
 }
 
 type NixContext struct {
@@ -144,19 +144,19 @@ func (ctx *NixContext) BuildMachines(deploymentPath string, hosts []Host, nixArg
 
 	resultLinkPath := filepath.Join(path.Dir(deploymentPath), ".gcroots", path.Base(deploymentPath))
 	if ctx.KeepGCRoot {
-	  if err = os.MkdirAll(path.Dir(resultLinkPath), 0755) ; err != nil {
-		  ctx.KeepGCRoot = false;
-		  fmt.Fprintf(os.Stderr, "Unable to create GC root, skipping: %s", err)
-	  }
+		if err = os.MkdirAll(path.Dir(resultLinkPath), 0755); err != nil {
+			ctx.KeepGCRoot = false
+			fmt.Fprintf(os.Stderr, "Unable to create GC root, skipping: %s", err)
+		}
 	}
-	if ! ctx.KeepGCRoot {
-	  // create tmp dir for result link
-	  tmpdir, err := ioutil.TempDir("", "morph-")
-	  if err != nil {
-		  return "", err
-	  }
-	  defer os.Remove(tmpdir)
-	  resultLinkPath = filepath.Join(tmpdir, "result")
+	if !ctx.KeepGCRoot {
+		// create tmp dir for result link
+		tmpdir, err := ioutil.TempDir("", "morph-")
+		if err != nil {
+			return "", err
+		}
+		defer os.Remove(tmpdir)
+		resultLinkPath = filepath.Join(tmpdir, "result")
 	}
 	args := []string{ctx.EvalMachines,
 		"-A", "machines",
@@ -180,8 +180,8 @@ func (ctx *NixContext) BuildMachines(deploymentPath string, hosts []Host, nixArg
 	}
 
 	cmd := exec.Command("nix-build", args...)
-	if ! ctx.KeepGCRoot {
-	  defer os.Remove(resultLinkPath)
+	if !ctx.KeepGCRoot {
+		defer os.Remove(resultLinkPath)
 	}
 
 	// show process output on attached stdout/stderr
@@ -249,7 +249,7 @@ func Push(ctx *ssh.SSHContext, host Host, paths ...string) (err error) {
 		keyArg = "?ssh-key=" + ctx.IdentityFile
 	}
 	if ctx.SkipHostKeyCheck {
-		env = append(env, fmt.Sprintf("NIX_SSHOPTS=%s","-o StrictHostkeyChecking=No -o UserKnownHostsFile=/dev/null"))
+		env = append(env, fmt.Sprintf("NIX_SSHOPTS=%s", "-o StrictHostkeyChecking=No -o UserKnownHostsFile=/dev/null"))
 	}
 
 	options := mkOptions(host)


### PR DESCRIPTION
Trying to make morph more configurable by allowing for pass-through of nix.conf options. It's now possible to provide an attribute set of configuration options (`nixConfig`) for each deployment. These options will be passed to both `nix-build` and `nix copy`. Unfortunately, because of the way morph does things, it's not possible to set nix config on a per-host level.

In an effort to also try and fix #73, i've added `substituteOnDestination` as a deployment module option. This option applies with per-host granularity.

While working on this, I considered just making the entire nix command-line available to the user, which would make any possible flag and option configurable. I rejected that idea for now though, because it turns out to be complicated. There are many permutations of per-host and per-deployment options and there should be a way in the API to then also distinguish flags intended for `nix-build` and `nix copy` or even `nix eval`. 

TLDR; I figured that would make the API too complicated at this point. I hope that this PR at least solves "some" problems.