### PR TITLE
Add support for target user name option

### DIFF
--- a/data/eval-machines.nix
+++ b/data/eval-machines.nix
@@ -72,7 +72,7 @@ rec {
 
     machines =
       flip mapAttrs nodes (n: v': let v = scrubOptionValue v'; in
-        { inherit (v.config.deployment) targetHost secrets healthChecks buildOnly substituteOnDestination;
+        { inherit (v.config.deployment) targetHost targetUser secrets healthChecks buildOnly substituteOnDestination;
           name = n;
           nixosRelease = v.config.system.nixos.release or (removeSuffix v.config.system.nixos.version.suffix v.config.system.nixos.version);
           nixConfig = mapAttrs

--- a/data/options.nix
+++ b/data/options.nix
@@ -159,6 +159,19 @@ in
 
     targetHost = mkOption {
       type = str;
+      default = "";
+      description = ''
+        The remote host used for deployment. If this is not set it will fallback to the deployments attribute name.
+      '';
+    };
+
+    targetUser = mkOption {
+      type = str;
+      default = "";
+      description = ''
+        The remote user used for deployment. If this is not set it will fallback to the user specified in the
+        <literal>SSH_USER</literal> environment variable or use the current local user as a last resort.
+      '';
     };
 
     buildOnly = mkOption {

--- a/healthchecks/types.go
+++ b/healthchecks/types.go
@@ -15,6 +15,7 @@ import (
 type Host interface {
 	GetName() string
 	GetTargetHost() string
+	GetTargetUser() string
 	GetHealthChecks() HealthChecks
 }
 

--- a/morph.go
+++ b/morph.go
@@ -394,7 +394,7 @@ func createSSHContext() *ssh.SSHContext {
 	return &ssh.SSHContext{
 		AskForSudoPassword: askForSudoPasswd,
 		IdentityFile:       os.Getenv("SSH_IDENTITY_FILE"),
-		Username:           os.Getenv("SSH_USER"),
+		DefaultUsername:    os.Getenv("SSH_USER"),
 		SkipHostKeyCheck:   os.Getenv("SSH_SKIP_HOST_KEY_CHECK") != "",
 	}
 }
@@ -588,7 +588,7 @@ func pushPaths(sshContext *ssh.SSHContext, filteredHosts []nix.Host, resultPath 
 		if err != nil {
 			return err
 		}
-		fmt.Fprintf(os.Stderr, "Pushing paths to %v (%v):\n", host.Name, host.TargetHost)
+		fmt.Fprintf(os.Stderr, "Pushing paths to %v (%v@%v):\n", host.Name, host.TargetUser, host.TargetHost)
 		for _, path := range paths {
 			fmt.Fprintf(os.Stderr, "\t* %s\n", path)
 		}

--- a/nix/nix.go
+++ b/nix/nix.go
@@ -22,7 +22,7 @@ type Host struct {
 	Name                    string
 	NixosRelease            string
 	TargetHost              string
-	TargetUser				string
+	TargetUser              string
 	Secrets                 map[string]secrets.Secret
 	BuildOnly               bool
 	SubstituteOnDestination bool

--- a/nix/nix.go
+++ b/nix/nix.go
@@ -22,6 +22,7 @@ type Host struct {
 	Name                    string
 	NixosRelease            string
 	TargetHost              string
+	TargetUser				string
 	Secrets                 map[string]secrets.Secret
 	BuildOnly               bool
 	SubstituteOnDestination bool
@@ -40,6 +41,10 @@ func (host *Host) GetName() string {
 
 func (host *Host) GetTargetHost() string {
 	return host.TargetHost
+}
+
+func (host *Host) GetTargetUser() string {
+	return host.TargetUser
 }
 
 func (host *Host) GetHealthChecks() healthchecks.HealthChecks {
@@ -246,8 +251,10 @@ func Push(ctx *ssh.SSHContext, host Host, paths ...string) (err error) {
 	var userArg = ""
 	var keyArg = ""
 	var env = os.Environ()
-	if ctx.Username != "" {
-		userArg = ctx.Username + "@"
+	if host.TargetUser != "" {
+		userArg = host.TargetUser + "@"
+	} else if ctx.DefaultUsername != "" {
+		userArg = ctx.DefaultUsername + "@"
 	}
 	if ctx.IdentityFile != "" {
 		keyArg = "?ssh-key=" + ctx.IdentityFile

--- a/ssh/ssh.go
+++ b/ssh/ssh.go
@@ -33,12 +33,13 @@ type Context interface {
 type Host interface {
 	GetName() string
 	GetTargetHost() string
+	GetTargetUser() string
 }
 
 type SSHContext struct {
 	sudoPassword       string
 	AskForSudoPassword bool
-	Username           string
+	DefaultUsername    string
 	IdentityFile       string
 	SkipHostKeyCheck   bool
 }
@@ -91,11 +92,12 @@ func (ctx *SSHContext) sshArgs(host Host, transfer *FileTransfer) (cmd string, a
 		args = append(args, transfer.Source)
 		hostAndDestination += ":" + transfer.Destination
 	}
-	if ctx.Username != "" {
-		args = append(args, ctx.Username+"@"+hostAndDestination)
-	} else {
-		args = append(args, hostAndDestination)
+	if host.GetTargetUser() != "" {
+		hostAndDestination = host.GetTargetUser() + "@" + hostAndDestination
+	} else if ctx.DefaultUsername != "" {
+		hostAndDestination = ctx.DefaultUsername + "@" + hostAndDestination
 	}
+	args = append(args, hostAndDestination)
 
 	return
 }


### PR DESCRIPTION
This adds a new deployment option called `targetUser` which specifies
the remote user used to for SSH connections during deployment. If the
option is not set, it falls back to the `SSH_USER` environment variable
or uses the curent local user as a last resort.