### PR TITLE
eval-machines: remove .drv file which pulls in unneeded deps

### DIFF
--- a/data/eval-machines.nix
+++ b/data/eval-machines.nix
@@ -95,7 +95,6 @@ rec {
         mkdir -p $out
         ${toString (mapAttrsToList (nodeName: nodeDef: ''
           ln -s ${nodeDef.config.system.build.toplevel} $out/${nodeName}
-          ln -s ${nodeDef.config.system.build.toplevel.drvPath} $out/${nodeName}.drv
         '') nodes')}
       ''
       else ''

--- a/nix/nix.go
+++ b/nix/nix.go
@@ -237,12 +237,7 @@ func GetPathsToPush(host Host, resultPath string) (paths []string, err error) {
 		return paths, err
 	}
 
-	path2, err := GetNixSystemDerivation(host, resultPath)
-	if err != nil {
-		return paths, err
-	}
-
-	paths = append(paths, path1, path2)
+	paths = append(paths, path1)
 
 	return paths, nil
 }


### PR DESCRIPTION
all credit goes to @delroth - proposed in https://github.com/DBCDK/morph/issues/69#issuecomment-544610117

I'm running this since quite some time on my systems, and it's a huge time (and bandwidth)-saver.