### PR TITLE
Implement finalizers

### DIFF
--- a/nix/nix.go
+++ b/nix/nix.go
@@ -8,6 +8,7 @@ import (
 	"github.com/dbcdk/morph/healthchecks"
 	"github.com/dbcdk/morph/secrets"
 	"github.com/dbcdk/morph/ssh"
+	"github.com/dbcdk/morph/utils"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -128,6 +129,11 @@ func (ctx *NixContext) GetMachines(deploymentPath string) (hosts []Host, err err
 	cmd.Stdout = &stdout
 	cmd.Stderr = os.Stderr
 
+	utils.AddFinalizer(func() {
+		if (cmd.ProcessState == nil || !cmd.ProcessState.Exited()) && cmd.Process != nil {
+			_ = cmd.Process.Signal(syscall.SIGTERM)
+		}
+	})
 	err = cmd.Run()
 	if err != nil {
 		errorMessage := fmt.Sprintf(
@@ -196,6 +202,11 @@ func (ctx *NixContext) BuildMachines(deploymentPath string, hosts []Host, nixArg
 	// show process output on attached stdout/stderr
 	cmd.Stdout = os.Stderr
 	cmd.Stderr = os.Stderr
+	utils.AddFinalizer(func() {
+		if (cmd.ProcessState == nil || !cmd.ProcessState.Exited()) && cmd.Process != nil {
+			_ = cmd.Process.Signal(syscall.SIGTERM)
+		}
+	})
 	err = cmd.Run()
 
 	if err != nil {

--- a/utils/finalizer.go
+++ b/utils/finalizer.go
@@ -1,0 +1,52 @@
+package utils
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+type finalizer struct {
+	function FinalizerFunc
+	executed bool
+}
+type FinalizerFunc func()
+
+var finalizers []*finalizer
+
+/*
+	Finalizers run sequentially at morph shutdown - both at clean shutdown and on errors.
+	Finalizers should be quick, simple and they need to ignore errors and don't panic.
+	Each finalizer will only run once and will _never_ be re-invoked.
+*/
+func (f *finalizer) Run() {
+	if !f.executed {
+		f.executed = true
+		f.function()
+	}
+}
+
+func RunFinalizers() {
+	for _, f := range finalizers {
+		f.Run()
+	}
+}
+
+func AddFinalizer(f FinalizerFunc) {
+	finalizers = append(finalizers, &finalizer{
+		function: f,
+		executed: false,
+	})
+}
+
+func SignalHandler() {
+	sigs := make(chan os.Signal, 1)
+	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		sig := <-sigs
+		fmt.Fprintf(os.Stderr, "Received signal: %s\n", sig.String())
+		RunFinalizers()
+		os.Exit(130) // reserved exit code for "Interrupted"
+	}()
+}


### PR DESCRIPTION
- to ensure that nix-cli processes get SIGTERM when morph receives SIGTERM or SIGINT
- to prepare for better cleanup of tmp-directories in morph in the future