### PR TITLE
Morph cleanup

### DIFF
--- a/morph.go
+++ b/morph.go
@@ -12,7 +12,6 @@ import (
 	"github.com/dbcdk/morph/secrets"
 	"github.com/dbcdk/morph/ssh"
 	"github.com/dbcdk/morph/utils"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -52,7 +51,6 @@ var (
 	executeCommand      []string
 	keepGCRoot          = app.Flag("keep-result", "Keep latest build in .gcroots to prevent it from being garbage collected").Default("False").Bool()
 
-	tempDir, tempDirErr  = ioutil.TempDir("", "morph-")
 	assetRoot, assetsErr = assets.Setup()
 )
 
@@ -215,10 +213,6 @@ func init() {
 	if assetsErr != nil {
 		fmt.Fprintln(os.Stderr, "Error unpacking assets:")
 		panic(assetsErr)
-	}
-
-	if tempDirErr != nil {
-		panic(tempDirErr)
 	}
 }
 

--- a/nix/nix.go
+++ b/nix/nix.go
@@ -170,7 +170,9 @@ func (ctx *NixContext) BuildMachines(deploymentPath string, hosts []Host, nixArg
 		if err != nil {
 			return "", err
 		}
-		defer os.Remove(tmpdir)
+		utils.AddFinalizer(func() {
+			os.RemoveAll(tmpdir)
+		})
 		resultLinkPath = filepath.Join(tmpdir, "result")
 	}
 	args := []string{ctx.EvalMachines,
@@ -195,9 +197,6 @@ func (ctx *NixContext) BuildMachines(deploymentPath string, hosts []Host, nixArg
 	}
 
 	cmd := exec.Command("nix-build", args...)
-	if !ctx.KeepGCRoot {
-		defer os.Remove(resultLinkPath)
-	}
 
 	// show process output on attached stdout/stderr
 	cmd.Stdout = os.Stderr

--- a/utils/finalizer.go
+++ b/utils/finalizer.go
@@ -46,7 +46,11 @@ func SignalHandler() {
 	go func() {
 		sig := <-sigs
 		fmt.Fprintf(os.Stderr, "Received signal: %s\n", sig.String())
-		RunFinalizers()
-		os.Exit(130) // reserved exit code for "Interrupted"
+		Exit(130) // reserved exit code for "Interrupted"
 	}()
+}
+
+func Exit(exitCode int) {
+	RunFinalizers()
+	os.Exit(exitCode)
 }


### PR DESCRIPTION
**main: remove generic tmp-dir**
* it's not used, and it causes tmpdirs to be created on shell-completion invocations

**misc: cleanup**

* ensure that finalizers are run on all program exists
* register removal of nix result tmpdir as finalizer

* cleanup code in morph.go
  * don't panic
  * re-introduce validateEnvironment
  * simplify some error handling