### PR TITLE
ssh-askpass: ensure term restore before unclean exit

### DIFF
--- a/ssh/ssh.go
+++ b/ssh/ssh.go
@@ -181,7 +181,15 @@ func (sshCtx *SSHContext) CmdInteractive(host Host, timeout int, parts ...string
 
 func askForSudoPassword() (string, error) {
 	fmt.Fprint(os.Stderr, "Please enter remote sudo password: ")
-	bytePassword, err := terminal.ReadPassword(int(syscall.Stdin))
+	stdin := int(syscall.Stdin)
+	state, err := terminal.GetState(stdin)
+	if err != nil {
+		return "", err
+	}
+	utils.AddFinalizer(func() {
+		terminal.Restore(stdin, state)
+	})
+	bytePassword, err := terminal.ReadPassword(stdin)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
At the time of sudo password prompt:

fixes a bug introduced by #93, where morph didn't restore terminal state (echo on), before exiting, after receiving Ctrl+C (interrupt) or term.