### PR TITLE
runtime deps: just-in-time check for ssh on $PATH

### DIFF
--- a/morph.go
+++ b/morph.go
@@ -13,7 +13,6 @@ import (
 	"github.com/dbcdk/morph/ssh"
 	"github.com/dbcdk/morph/utils"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 )
@@ -206,7 +205,7 @@ func listSecretsCmd(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 }
 
 func setup() {
-	handleError(validateEnvironment())
+	utils.ValidateEnvironment("nix")
 
 	utils.AddFinalizer(func() {
 		assets.Teardown(assetRoot)
@@ -218,22 +217,7 @@ func setup() {
 	handleError(assetErr)
 }
 
-func validateEnvironment() (err error) {
-	dependencies := []string{"nix", "scp", "ssh"}
-	missingDepencies := make([]string, 0)
-	for _, dependency := range dependencies {
-		_, err := exec.LookPath(dependency)
-		if err != nil {
-			missingDepencies = append(missingDepencies, dependency)
-		}
-	}
 
-	if len(missingDepencies) > 0 {
-		return errors.New("Missing dependencies: " + strings.Join(missingDepencies, ", "))
-	}
-
-	return nil
-}
 
 func main() {
 

--- a/nix/nix.go
+++ b/nix/nix.go
@@ -253,6 +253,8 @@ func GetPathsToPush(host Host, resultPath string) (paths []string, err error) {
 }
 
 func Push(ctx *ssh.SSHContext, host Host, paths ...string) (err error) {
+	utils.ValidateEnvironment("ssh")
+
 	var userArg = ""
 	var keyArg = ""
 	var env = os.Environ()

--- a/ssh/ssh.go
+++ b/ssh/ssh.go
@@ -77,6 +77,7 @@ func (ctx *SSHContext) sshArgs(host Host, transfer *FileTransfer) (cmd string, a
 	} else {
 		cmd = "ssh"
 	}
+	utils.ValidateEnvironment(cmd)
 
 	if ctx.SkipHostKeyCheck {
 		args = append(args,

--- a/utils/files.go
+++ b/utils/files.go
@@ -1,7 +1,12 @@
 package utils
 
 import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 )
 
 func GetAbsPathRelativeTo(path string, reference string) string {
@@ -9,5 +14,20 @@ func GetAbsPathRelativeTo(path string, reference string) string {
 		return path
 	} else {
 		return filepath.Join(reference, path)
+	}
+}
+
+func ValidateEnvironment(dependencies ...string)  {
+	missingDepencies := make([]string, 0)
+	for _, dependency := range dependencies {
+		_, err := exec.LookPath(dependency)
+		if err != nil {
+			missingDepencies = append(missingDepencies, dependency)
+		}
+	}
+
+	if len(missingDepencies) > 0 {
+		fmt.Fprint(os.Stderr, errors.New("Missing dependencies: '" + strings.Join(missingDepencies, ", ") + "' on $PATH"))
+		Exit(1)
 	}
 }


### PR DESCRIPTION
This delays the runtime PATH-check for `ssh` and `scp` until they are needed, respectively.
Nix is still required on PATH at startup, since morph is effectively unusable without it.

fixes nixos/nixpkgs#78106