### PR TITLE
Add support for ports in hostnames

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 *.iml
 .idea
 
+bindata.go
+
 # Default binary output file name
 /morph
 

--- a/morph.go
+++ b/morph.go
@@ -4,6 +4,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
 	"github.com/dbcdk/kingpin"
 	"github.com/dbcdk/morph/assets"
 	"github.com/dbcdk/morph/filter"
@@ -12,9 +16,6 @@ import (
 	"github.com/dbcdk/morph/secrets"
 	"github.com/dbcdk/morph/ssh"
 	"github.com/dbcdk/morph/utils"
-	"os"
-	"path/filepath"
-	"strings"
 )
 
 // This is set at build time via -ldflags magic

--- a/ssh/ssh.go
+++ b/ssh/ssh.go
@@ -5,8 +5,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/dbcdk/morph/utils"
-	"golang.org/x/crypto/ssh/terminal"
 	"io"
 	"os"
 	"os/exec"
@@ -14,6 +12,9 @@ import (
 	"strings"
 	"syscall"
 	"time"
+
+	"github.com/dbcdk/morph/utils"
+	"golang.org/x/crypto/ssh/terminal"
 )
 
 type Context interface {
@@ -85,6 +86,7 @@ func (ctx *SSHContext) sshArgs(host Host, transfer *FileTransfer) (cmd string, a
 			"-o", "StrictHostKeyChecking=No",
 			"-o", "UserKnownHostsFile=/dev/null")
 	}
+
 	if ctx.IdentityFile != "" {
 		args = append(args, "-i")
 		args = append(args, ctx.IdentityFile)
@@ -92,17 +94,29 @@ func (ctx *SSHContext) sshArgs(host Host, transfer *FileTransfer) (cmd string, a
 	if ctx.ConfigFile != "" {
 		args = append(args, "-F", ctx.ConfigFile)
 	}
-	var hostAndDestination = host.GetTargetHost()
+
+	target, port := utils.SplitHost(host.GetTargetHost())
+	if port != "" {
+		switch cmd {
+		case "scp":
+			args = append(args, "-P", port)
+		case "ssh":
+			args = append(args, "-p", port)
+		}
+	}
+
 	if transfer != nil {
 		args = append(args, transfer.Source)
-		hostAndDestination += ":" + transfer.Destination
+		target += ":" + transfer.Destination
 	}
+
 	if host.GetTargetUser() != "" {
-		hostAndDestination = host.GetTargetUser() + "@" + hostAndDestination
+		target = host.GetTargetUser() + "@" + target
 	} else if ctx.DefaultUsername != "" {
-		hostAndDestination = ctx.DefaultUsername + "@" + hostAndDestination
+		target = ctx.DefaultUsername + "@" + target
 	}
-	args = append(args, hostAndDestination)
+
+	args = append(args, target)
 
 	return
 }

--- a/utils/host.go
+++ b/utils/host.go
@@ -1,0 +1,11 @@
+package utils
+
+import "strings"
+
+func SplitHost(host string) (string, string) {
+	var parts = strings.SplitN(host, ":", 2)
+	if len(parts) > 1 {
+		return parts[0], parts[1]
+	}
+	return host, ""
+}


### PR DESCRIPTION
Something like this:

```nix
{
    network = {
        inherit pkgs;
    };
    "root@192.168.1.169:737" = { config, pkgs, lib, ... }: {};
}
```

This has been tested with `morph deploy default.nix switch` only.

Side note: The go.mod PR should be completed (to prevent things like the second commit of this PR)