### PR TITLE
Employ new documentation.nixos.extraModuleSources option

### DIFF
--- a/assets/utils.go
+++ b/assets/utils.go
@@ -6,8 +6,16 @@ import (
 	"path/filepath"
 )
 
+const Friendly string = "morph"
+
 func Setup() (assetRoot string, err error) {
 	assetRoot, err = ioutil.TempDir("", "morph-")
+	if err != nil {
+		return "", err
+	}
+
+	assetFriendlyRoot := filepath.Join(assetRoot, Friendly)
+	err = os.Mkdir(assetFriendlyRoot, 0755)
 	if err != nil {
 		return "", err
 	}
@@ -22,8 +30,8 @@ func Setup() (assetRoot string, err error) {
 		return "", err
 	}
 
-	evalMachinesPath := filepath.Join(assetRoot, "eval-machines.nix")
-	optionsPath := filepath.Join(assetRoot, "options.nix")
+	evalMachinesPath := filepath.Join(assetFriendlyRoot, "eval-machines.nix")
+	optionsPath := filepath.Join(assetFriendlyRoot, "options.nix")
 	ioutil.WriteFile(evalMachinesPath, evalMachinesData, 0644)
 	ioutil.WriteFile(optionsPath, optionsData, 0644)
 
@@ -31,12 +39,19 @@ func Setup() (assetRoot string, err error) {
 }
 
 func Teardown(assetRoot string) (err error) {
-	err = os.Remove(filepath.Join(assetRoot, "eval-machines.nix"))
+	assetFriendlyRoot := filepath.Join(assetRoot, Friendly)
+
+	err = os.Remove(filepath.Join(assetFriendlyRoot, "eval-machines.nix"))
 	if err != nil {
 		return err
 	}
 
-	err = os.Remove(filepath.Join(assetRoot, "options.nix"))
+	err = os.Remove(filepath.Join(assetFriendlyRoot, "options.nix"))
+	if err != nil {
+		return err
+	}
+
+	err = os.Remove(assetFriendlyRoot)
 	if err != nil {
 		return err
 	}

--- a/data/eval-machines.nix
+++ b/data/eval-machines.nix
@@ -27,6 +27,9 @@ rec {
             [ ({ config, lib, options, ... }: {
                 key = "deploy-stuff";
                 imports = [ ./options.nix ];
+                # Make documentation builds deterministic, even with our
+                # tempdir module imports.
+                documentation.nixos.extraModuleSources = [ ../. ];
                 # Provide a default hostname and deployment target equal
                 # to the attribute name of the machine in the model.
                 networking.hostName = lib.mkDefault machineName;

--- a/morph.go
+++ b/morph.go
@@ -534,7 +534,7 @@ func getHosts(deploymentFile string) (hosts []nix.Host, err error) {
 
 func getNixContext() *nix.NixContext {
 	return &nix.NixContext{
-		EvalMachines: filepath.Join(assetRoot, "eval-machines.nix"),
+		EvalMachines: filepath.Join(assetRoot, assets.Friendly, "eval-machines.nix"),
 		ShowTrace:    showTrace,
 		KeepGCRoot:   *keepGCRoot,
 	}

--- a/nix-packaging/default.nix
+++ b/nix-packaging/default.nix
@@ -29,7 +29,7 @@ buildGoPackage rec {
     main.version=${version}
   '';
 
-  prePatch = ''
+  postPatch = ''
     go-bindata -pkg assets -o assets/assets.go data/
   '';
 


### PR DESCRIPTION
Deterministic manual builds with `documentation.nixos.includeAllModules`! The friendly extension to the asset path is so you'll see "morph/options.nix" instead of "options.nix" when the manual mentions where morph's options are from.

Note that this depends on the option's presence in NixOS, and it probably won't be commonly available for a little while after merge (PR NixOS/nixpkgs#81557). I'm hoping for a 20.03 backport so this can be solved for the next stable.

To work around this in the meantime, a per-machine nixpkgs arg can be provided along the lines of:
```nix
let
  # for pkgs.applyPatches
  # (if you're using niv this has already been evaluated)
  bootstrapPkgs = import <nixpkgs> { };

  nixpkgsArgs = {
    config = { allowUnfree = false; };
  };
  # https://github.com/NixOS/nixpkgs/pull/81557
  nixpkgsExtraSourcesPatch = bootstrapPkgs.fetchPatch {
    url = https://github.com/NixOS/nixpkgs/commit/7535c42ebf14618e6c32577a7e2150f0cd522803.patch;
    sha256 = "0ph6xzg7j89lcjpxklhvgkvp3qmqhplhnq6p4l84b06h3krcb876";
  };
  importNixpkgs = nixpkgs: let
    nixpkgs' = bootstrapPkgs.applyPatches {
      src = nixpkgs.outPath or nixpkgs;
      patches = [ nixpkgsExtraSourcesPatch ];
    };      
  in import nixpkgs' nixpkgsArgs;
in {
  # replace <nixpkgs> with your preferred Nixpkgs source
  network.pkgs = importNixpkgs <nixpkgs>;
}
```

If you're already using [`niv`](https://github.com/nmattia/niv), though, this can be shortened by wrapping `nix/sources.nix` with approximately:
```nix
let
  # ...
in sources // rec {
  pkgs = importNixpkgs sources.nixpkgs;
  # if you have a nixpkgs-unstable source:
  pkgs-unstable = importNixpkgs sources.nixpkgs-unstable;
}
```
and then just inheriting `pkgs` where desired generally (`network = { inherit pkgs; };` in this particular case). This also makes sure you don't miss patching when changing Nixpkgs providers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dbcdk/morph/108)
<!-- Reviewable:end -->
