### PR TITLE
add a SSH_CONFIG_FILE option

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ Morph supports the following (optional) environment variables:
 - `SSH_IDENTITY_FILE` the (local) path to the SSH private key file that should be used
 - `SSH_USER` specifies the user that should be used to connect to the remote system
 - `SSH_SKIP_HOST_KEY_CHECK` if set disables host key verification
+- `SSH_CONFIG_FILE` allows to change the location of the ~/.ssh/config file
 
 ### Secrets
 

--- a/morph.go
+++ b/morph.go
@@ -408,6 +408,7 @@ func createSSHContext() *ssh.SSHContext {
 		IdentityFile:       os.Getenv("SSH_IDENTITY_FILE"),
 		DefaultUsername:    os.Getenv("SSH_USER"),
 		SkipHostKeyCheck:   os.Getenv("SSH_SKIP_HOST_KEY_CHECK") != "",
+		ConfigFile:         os.Getenv("SSH_CONFIG_FILE"),
 	}
 }
 

--- a/ssh/ssh.go
+++ b/ssh/ssh.go
@@ -41,6 +41,7 @@ type SSHContext struct {
 	AskForSudoPassword bool
 	DefaultUsername    string
 	IdentityFile       string
+	ConfigFile         string
 	SkipHostKeyCheck   bool
 }
 
@@ -86,6 +87,9 @@ func (ctx *SSHContext) sshArgs(host Host, transfer *FileTransfer) (cmd string, a
 	if ctx.IdentityFile != "" {
 		args = append(args, "-i")
 		args = append(args, ctx.IdentityFile)
+	}
+	if ctx.ConfigFile != "" {
+		args = append(args, "-F", ctx.ConfigFile)
 	}
 	var hostAndDestination = host.GetTargetHost()
 	if transfer != nil {


### PR DESCRIPTION
Sometimes it's useful to have a per-project SSH config. That config
might for example be generated by:

    export SSH_CONFIG_FILE=$(direnv_layout_dir)/ssh_config
    gcloud compute config-ssh --ssh-config-file="$SSH_CONFIG_FILE"

This option is a bit of a superset from all the other SSH_* env vars as
the ssh config file itself allows to set all of those other options.