### PR TITLE
nix-packaging: buildGoPackage no longer produces the $bin output

### DIFF
--- a/nix-packaging/default.nix
+++ b/nix-packaging/default.nix
@@ -38,7 +38,7 @@ buildGoPackage rec {
     cp -v $src/data/*.nix $lib
   '';
 
-  outputs = [ "out" "bin" "lib" ];
+  outputs = [ "out" "lib" ];
 
   meta = {
     homepage = "https://github.com/dbcdk/morph";

--- a/shell.nix
+++ b/shell.nix
@@ -6,9 +6,9 @@ let
   packagingOut = "./nix-packaging";
 
   shellHook = ''
-    if [[ -f ./result-bin/bin/morph ]]; then
+    if [[ -f ./result/bin/morph ]]; then
       if [[ `${which} morph 2>&1 >/dev/null` ]]; then
-        export PATH=$PATH:$(pwd)/result-bin/bin
+        export PATH=$PATH:$(pwd)/result/bin
       fi
       source <(morph --completion-script-bash)
     fi
@@ -38,7 +38,7 @@ let
     outpath="$(readlink -f ${packagingOut})/deps.nix"
 
     ${nix}/bin/nix-build -E 'with import <nixpkgs> {};
-      callPackage ./nix-packaging/default.nix {}' -A bin $@
+      callPackage ./nix-packaging/default.nix {}' -A out $@
 
     make-env
   '';


### PR DESCRIPTION
fixes #114

Not exactly a backward compatible fix for #114, but IMHO it makes sense to not depend on the $bin output at all, since buildGoPackage no longer uses it.

While this breaks the build of morph with nixpkgs-20.03, morph v1.4.0 continues to be buildable with 20.03 packages.

We'll then release morph v1.5.0 and PR it against nixpkgs master, including a remark on missing backward compatibility in the release notes.

@adamtulinius @srhb let me hear your thoughts.