### PR TITLE
Allow evaluation in restricted mode

### DIFF
--- a/data/eval-machines.nix
+++ b/data/eval-machines.nix
@@ -5,7 +5,7 @@ let
   network      = import networkExpr;
   nwPkgs       = network.network.pkgs or {};
   lib          = network.network.lib or nwPkgs.lib or (import <nixpkgs/lib>);
-  evalConfig   = network.network.evalConfig or "${nwPkgs.path or <nixpkgs>}/nixos/lib/eval-config.nix";
+  evalConfig   = network.network.evalConfig or ((nwPkgs.path or <nixpkgs>) + "/nixos/lib/eval-config.nix");
   runCommand   = network.network.runCommand or nwPkgs.runCommand or ((import <nixpkgs> {}).runCommand);
 in
   with lib;


### PR DESCRIPTION
This allows running the evaluation in Hydra builds.

I was unable to test it with the master branch, as `make-build` fails:
```
mkdir: missing operand
Try 'mkdir --help' for more information.
builder for '/nix/store/m8m4bnzlvv7v2wwm68hks76fjm7nd4jq-morph-unstable-dev.drv' failed with exit code 1
error: build of '/nix/store/m8m4bnzlvv7v2wwm68hks76fjm7nd4jq-morph-unstable-dev.drv' faile
```