### PR TITLE
Experimental network.buildShell

### DIFF
--- a/data/eval-machines.nix
+++ b/data/eval-machines.nix
@@ -73,11 +73,14 @@ rec {
 
     machineList = (map (key: getAttr key machines) (attrNames machines));
     network = network'.network or {};
+    buildShell = network.buildShell.drvPath or null;
   };
 
   # Phase 2: build complete machine configurations.
-  machines = { names, buildTargets ? null }:
-    let nodes' = filterAttrs (n: v: elem n names) nodes; in
+  machines = { argsFile, buildTargets ? null }:
+    let
+      fileArgs = builtins.fromJSON (builtins.readFile argsFile);
+      nodes' = filterAttrs (n: v: elem n fileArgs.Names) nodes; in
     runCommand "morph"
       { preferLocalBuild = true; }
       (if buildTargets == null

--- a/nix/nix.go
+++ b/nix/nix.go
@@ -14,9 +14,9 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"time"
-  "strings"
 )
 
 type Host struct {
@@ -265,7 +265,7 @@ func (ctx *NixContext) BuildMachines(deploymentPath string, hosts []Host, nixArg
 
 	var cmd *exec.Cmd
 	if buildShell != nil {
-		shellArgs := strings.Join(append([]string{"nix-build"},args...), " ")
+		shellArgs := strings.Join(append([]string{"nix-build"}, args...), " ")
 		cmd = exec.Command("nix-shell", *buildShell, "--run", shellArgs)
 	} else {
 		cmd = exec.Command("nix-build", args...)


### PR DESCRIPTION
Basic testing done.

This grants users a medium-to-large escape hatch in that they may define `network.buildShell` to be a shell-compatible drv from which morph can and will execute `nix-build`.

One could, for instance, override the `nix-build` that's on `$PATH` by using this. Or just have funny messages displayed whenever a shell is opened.

```
    network.buildShell = pkgs.mkShell {
      name = "test";
      shellHook = ''
        echo "Woo, here we go!"
      '';
    };
```