### PR TITLE
shell.nix: Use nixos-unstable by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ machine2 = { ... }: {
 
 ## Hacking morph
 
-All commands mentioned below is available in the nix-shell, if you run `nix-shell` with working dir = project root.
+All commands mentioned below is available in the nix-shell, if you run `nix-shell` with working dir = project root. The included `shell.nix` uses the latest `nixos-unstable` from GitHub by default, but you can override this by passing in another, eg. `nix-shell --arg nixpkgs '<nixpkgs>'` for your `$NIX_PATH` nixpkgs.
 
 
 ### Go dependency management

--- a/shell.nix
+++ b/shell.nix
@@ -1,4 +1,6 @@
-{ pkgs ? (import <nixpkgs> {}) }:
+{ nixpkgs ? builtins.fetchTarball "https://github.com/NixOS/nixpkgs/archive/nixos-unstable.tar.gz"
+, pkgs ? import nixpkgs {}
+}:
 
 with pkgs;
 let


### PR DESCRIPTION
master does not build against nixos-stable. This is confusing for users of a stable NixOS branch, so grab a nixos-unstable by default in the shell.