### PR TITLE
shell: actually use the nixpkgs pin for building morph

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: nix
-nix: 2.1.1
+nix: 2.3.6
 script: nix-shell --run 'make-build'

--- a/shell.nix
+++ b/shell.nix
@@ -39,7 +39,7 @@ let
 
     outpath="$(readlink -f ${packagingOut})/deps.nix"
 
-    ${nix}/bin/nix-build -E 'with import <nixpkgs> {};
+    ${nix}/bin/nix-build -E 'with import ${nixpkgs} {};
       callPackage ./nix-packaging/default.nix {}' -A out $@
 
     make-env


### PR DESCRIPTION
Somehow we missed this during both the crafting and review of #119 , which was supposed to fix the error now re-reported in #122. Sorry. This PR should fix the issue.

I guess you can say the morph dev-shell needs a little love in general.

Thanks @glasserc for reporting this.

fixes #122

PS. now that Travis also started building using nixos-unstable, the build fails with nix being too old; hence the travis nix-bump.