### PR TITLE
Fix honouring of nixpkgs.config

### DIFF
--- a/data/eval-machines.nix
+++ b/data/eval-machines.nix
@@ -36,7 +36,9 @@ rec {
                 deployment.targetHost = lib.mkDefault machineName;
 
                 # If network.pkgs is set, mkDefault nixpkgs.pkgs
-                nixpkgs.pkgs = lib.mkIf (nwPkgs != {}) (lib.mkDefault nwPkgs);
+                nixpkgs.pkgs = lib.mkIf (nwPkgs != {}) (lib.mkDefault nwPkgs {
+                    config = config.nixpkgs.config;
+                });
               })
             ];
           extraArgs = { inherit nodes ; name = machineName; };


### PR DESCRIPTION
This should honour modules that declare:

```nix
{
  nixpkgs.config.allowUnfree = true;
}
```

_lazy evaluation is like magic_