### PR TITLE
Passed nixpkgs to rule them all

### DIFF
--- a/data/eval-machines.nix
+++ b/data/eval-machines.nix
@@ -34,11 +34,9 @@ rec {
                 # to the attribute name of the machine in the model.
                 networking.hostName = lib.mkDefault machineName;
                 deployment.targetHost = lib.mkDefault machineName;
-
-                # If network.pkgs is set, mkDefault nixpkgs.pkgs
-                nixpkgs.pkgs = lib.mkIf (nwPkgs != {}) (lib.mkDefault nwPkgs);
               })
             ];
+          pkgs = lib.mkIf (nwPkgs != {}) nwPkgs;
           extraArgs = { inherit nodes ; name = machineName; };
         };
       }


### PR DESCRIPTION
Alternative to #135 

This might have the disadvantage that individual deployments will be barred from pinning different versions, which one would wish to do on a release branch for a group of deployment to mimic a canary deploy.