### PR TITLE
Create lib derivation using correct resources

### DIFF
--- a/nix-packaging/default.nix
+++ b/nix-packaging/default.nix
@@ -35,7 +35,7 @@ buildGoPackage rec {
 
   postInstall = ''
     mkdir -p $lib
-    cp -v $src/data/*.nix $lib
+    cp -v go/src/$goPackagePath/data/*.nix $lib
   '';
 
   outputs = [ "out" "lib" ];


### PR DESCRIPTION
This changes the installation of assets from `data` into `morph.lib` to respect any modification done to the source during previous build steps.

I'm using a patch to modify assets using `overrideAttrs`. The old version used the modified (correct) files to create the bundled resources in the morph binary but does not use the modified files to create the `lib` derivation. This is changed by using the same files as used during the build of the binary. Now the patch is also reflected in the `lib` derivation.