### PR TITLE
nix: add config file to NIX_SSHOPTS

### DIFF
--- a/nix/nix.go
+++ b/nix/nix.go
@@ -350,6 +350,7 @@ func Push(ctx *ssh.SSHContext, host Host, paths ...string) (err error) {
 
 	var userArg = ""
 	var keyArg = ""
+	var sshOpts = []string{}
 	var env = os.Environ()
 	if host.TargetUser != "" {
 		userArg = host.TargetUser + "@"
@@ -360,7 +361,13 @@ func Push(ctx *ssh.SSHContext, host Host, paths ...string) (err error) {
 		keyArg = "?ssh-key=" + ctx.IdentityFile
 	}
 	if ctx.SkipHostKeyCheck {
-		env = append(env, fmt.Sprintf("NIX_SSHOPTS=%s", "-o StrictHostkeyChecking=No -o UserKnownHostsFile=/dev/null"))
+  		sshOpts = append(sshOpts, fmt.Sprintf("%s", "-o StrictHostkeyChecking=No -o UserKnownHostsFile=/dev/null"))
+	}
+	if ctx.ConfigFile != "" {
+  		sshOpts = append(sshOpts, fmt.Sprintf("-F %s", ctx.ConfigFile))
+	}
+	if len(sshOpts) > 0 {
+		env = append(env, fmt.Sprintf("NIX_SSHOPTS=%s", strings.Join(sshOpts, " ")))
 	}
 
 	options := mkOptions(host)


### PR DESCRIPTION
Fixes https://github.com/DBCDK/morph/issues/140.

---

I don't actually use Morph (yet?), but I semi-validated that this *should* work by printing the value of `sshOpts`, which showed `[-o StrictHostkeyChecking=No -o UserKnownHostsFile=/dev/null -F /tmp]` when running `SSH_SKIP_HOST_KEY_CHECK=true SSH_CONFIG_FILE=/tmp result/bin/morph push ./examples/healthchecks.nix`.