### PR TITLE
secrets: add uploadAt option

### DIFF
--- a/data/options.nix
+++ b/data/options.nix
@@ -62,6 +62,17 @@ keyOptionsType = submodule ({ ... }: {
         prior to moving the secret in place.
       '';
     };
+
+    uploadAt = mkOption {
+      default = "pre-activation";
+      type = enum [ "pre-activation" "post-activation" ];
+      description = ''
+        When to upload the secret.
+
+        `pre-activation` (the default) will upload the secret and run any associated action prior to activating the system configuration.
+        `post-activation` will upload the secret and run any associated action after activating the system configuration.
+      '';
+    };
   };
 });
 

--- a/morph.go
+++ b/morph.go
@@ -371,6 +371,14 @@ func execDeploy(hosts []nix.Host) (string, error) {
 			}
 		}
 
+		if deployReboot {
+			err = host.Reboot(sshContext)
+			if err != nil {
+				fmt.Fprintln(os.Stderr, "Reboot failed")
+				return "", err
+			}
+		}
+
 		if doUploadSecrets {
 			phase := "post-activation"
 			err = execUploadSecrets(sshContext, singleHostInList, &phase)
@@ -379,14 +387,6 @@ func execDeploy(hosts []nix.Host) (string, error) {
 			}
 
 			fmt.Fprintln(os.Stderr)
-		}
-
-		if deployReboot {
-			err = host.Reboot(sshContext)
-			if err != nil {
-				fmt.Fprintln(os.Stderr, "Reboot failed")
-				return "", err
-			}
 		}
 
 		if !skipHealthChecks {

--- a/secrets/types.go
+++ b/secrets/types.go
@@ -10,6 +10,7 @@ type Secret struct {
 	Permissions string
 	Action      []string
 	MkDirs      bool
+	UploadAt    string
 }
 
 type Owner struct {
@@ -20,8 +21,8 @@ type Owner struct {
 func (s *Secret) String() string {
 	var string_repr strings.Builder
 
-	fmt.Fprintf(&string_repr, "`%s` -> `%s`, with:\n\tPermissions: %s:%s, %s\n\tCreate remote directories: %t",
-		s.Source, s.Destination, s.Owner.User, s.Owner.Group, s.Permissions, s.MkDirs)
+	fmt.Fprintf(&string_repr, "`%s` -> `%s`, with:\n\tPermissions: %s:%s, %s\n\tCreate remote directories: %t\n\tUpload at: %s",
+		s.Source, s.Destination, s.Owner.User, s.Owner.Group, s.Permissions, s.MkDirs, s.UploadAt)
 
 	if len(s.Action) > 0 {
 		fmt.Fprintf(&string_repr, "\n\tAction: `%s`", strings.Join(s.Action, " "))


### PR DESCRIPTION
This allows specifying when to upload the secret. This allows the secret to
depend on permissions (users, groups) that don't already exist.

---

~~should the `post-activation` upload be moved to after the reboot block? I think that would wholly resolve https://github.com/DBCDK/morph/issues/99.~~

ETA: I tested both `morph upload-secrets` and `morph deploy --upload-secrets`, and they both satisfy the suggestions in the above issue.