### PR TITLE
Wait for mountpoints before deploying secrets

### DIFF
--- a/secrets/secrets.go
+++ b/secrets/secrets.go
@@ -47,6 +47,11 @@ func GetSecretSize(secret Secret, deploymentWD string) (size int64, err error) {
 func UploadSecret(ctx ssh.Context, host ssh.Host, secret Secret, deploymentWD string) *SecretError {
 	var partialErr *SecretError
 
+	err := ctx.WaitForMountPoints(host, secret.Destination)
+	if err != nil {
+		return wrap(err)
+	}
+
 	tempPath, err := ctx.MakeTempFile(host)
 	if err != nil {
 		return wrap(err)


### PR DESCRIPTION
Use systemd to ensure all configured mountpoints for a certain path are
mounted before we start uploading a secret.

This prevents issues like accidentally writing to the underlying
filesystem and then being overlayed by a filesystem, or worse persisting
secrets onto disk, when they should've been copied onto volatile
storage.

I'm a go amateur, I ran go build as well as go test, <s>but have yet to try this out together with #158.</s> wfm.