### PR TITLE
add documentation of `nodes`

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,33 @@ machine2 = { ... }: {
 };
 ```
 
+**mutually recursive configurations**
+Each host's configuration has access to a `nodes` argument, which contains the compiled configurations of all hosts.
+
+```
+machine1 = { nodes, ... }: {
+    hostnames.machine2 = 
+        (builtins.head nodes.machine2.networking.interfaces.foo.ipv4.addresses).address;
+    networking.interfaces.foo.ipv4.addresses = [
+        {
+            address = "10.0.0.10";
+            prefixLength = 32;
+        }
+    ];
+}
+
+machine2 = { nodes, ... }: {
+    hostnames.machine1 = 
+        (builtins.head nodes.machine1.networking.interfaces.foo.ipv4.addresses).address;
+    networking.interfaces.foo.ipv4.addresses = [
+        {
+            address = "10.0.0.20";
+            prefixLength = 32;
+        }
+    ];
+}
+```
+
 
 ## Hacking morph
 


### PR DESCRIPTION
It took us a long time recently to figure out that the `nodes` argument existed. I was even about to reimplement similar functionality because I thought morph didn't have it.

We eventually found it [mentioned in a comment](https://github.com/DBCDK/morph/blob/master/data/eval-machines.nix#L40) but still had to figure out what the argument was called.

This PR just adds to the readme a short paragraph and an example.