### PR TITLE
Expose eval as nix attribute.

### DIFF
--- a/data/eval-machines.nix
+++ b/data/eval-machines.nix
@@ -1,9 +1,9 @@
 # Completely stripped down version of nixops' evaluator
-{ networkExpr }:
+{ networkExpr, pkgs ? {} }:
 
 let
   network      = import networkExpr;
-  nwPkgs       = network.network.pkgs or {};
+  nwPkgs       = network.network.pkgs or pkgs;
   lib          = network.network.lib or nwPkgs.lib or (import <nixpkgs/lib>);
   evalConfig   = network.network.evalConfig or ((nwPkgs.path or <nixpkgs>) + "/nixos/lib/eval-config.nix");
   runCommand   = network.network.runCommand or nwPkgs.runCommand or ((import <nixpkgs> {}).runCommand);

--- a/default.nix
+++ b/default.nix
@@ -3,35 +3,41 @@
 , version ? "dev"
 }:
 
-pkgs.buildGoModule rec {
-  name = "morph-unstable-${version}";
-  inherit version;
+let
+  morph = pkgs.buildGoModule rec {
+    name = "morph-unstable-${version}";
+    inherit version;
 
-  nativeBuildInputs = with pkgs; [ go-bindata ];
+    nativeBuildInputs = with pkgs; [ go-bindata ];
 
-  src = pkgs.nix-gitignore.gitignoreSource [] ./.;
+    src = pkgs.nix-gitignore.gitignoreSource [] ./.;
 
-  buildFlagsArray = ''
-    -ldflags=
-    -X
-    main.version=${version}
-  '';
+    buildFlagsArray = ''
+      -ldflags=
+      -X
+      main.version=${version}
+    '';
 
-  vendorSha256 = "08zzp0h4c4i5hk4whz06a3da7qjms6lr36596vxz0d8q0n7rspr9";
+    vendorSha256 = "08zzp0h4c4i5hk4whz06a3da7qjms6lr36596vxz0d8q0n7rspr9";
 
-  postPatch = ''
-    go-bindata -pkg assets -o assets/assets.go data/
-  '';
+    postPatch = ''
+      go-bindata -pkg assets -o assets/assets.go data/
+    '';
 
-  postInstall = ''
-    mkdir -p $lib
-    cp -v ./data/*.nix $lib
-  '';
+    postInstall = ''
+      mkdir -p $lib
+      cp -v ./data/*.nix $lib
+    '';
 
-  outputs = [ "out" "lib" ];
+    outputs = [ "out" "lib" ];
 
-  meta = {
-    homepage = "https://github.com/DBCDK/morph";
-    description = "Morph is a NixOS host manager written in Golang.";
+    passthru = {
+      eval = args@{...}: (import (morph.lib + "/eval-machines.nix")) ({ inherit pkgs; } // args);
+    };
+
+    meta = {
+      homepage = "https://github.com/DBCDK/morph";
+      description = "Morph is a NixOS host manager written in Golang.";
+    };
   };
-}
+in morph


### PR DESCRIPTION
This allows using the nix portion of morph, without needing to know implementation details of where the nix expression is.

I'm not sure if the attributes exposed there want to be made public, or perhaps only some of them should be public.