### PR TITLE
Migrate from buildFlagsArray to ldflags

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -11,11 +11,9 @@ pkgs.buildGoModule rec {
 
   src = pkgs.nix-gitignore.gitignoreSource [] ./.;
 
-  buildFlagsArray = ''
-    -ldflags=
-    -X
-    main.version=${version}
-  '';
+  ldflags = [
+    "-X main.version=${version}"
+  ];
 
   vendorSha256 = "08zzp0h4c4i5hk4whz06a3da7qjms6lr36596vxz0d8q0n7rspr9";
 


### PR DESCRIPTION
On recent nixpkgs-unstable versions usage of buildFlagsArray causes the
following warning:

```
trace: warning: Use the `ldflags` and/or `tags` attributes instead of `buildFlags`/`buildFlagsArray`
```

```
❯ ./result/bin/morph --version
dev
```
