### PR TITLE
Add eval command

### DIFF
--- a/morph.go
+++ b/morph.go
@@ -248,22 +248,22 @@ func main() {
 	if len(nixBuildArg) > 0 {
 		fmt.Fprintln(os.Stderr, "Deprecation: The --build-arg flag will be removed in a future release.")
 	}
-	
+
 	defer utils.RunFinalizers()
-	setup()	
-	
+	setup()
+
 	// evaluate without building hosts
 	switch clause {
-		case eval.FullCommand():
-			_, err := execEval()
-			handleError(err)
-			return
+	case eval.FullCommand():
+		_, err := execEval()
+		handleError(err)
+		return
 	}
-	
+
 	// setup hosts
 	hosts, err := getHosts(deployment)
 	handleError(err)
-	
+
 	switch clause {
 	case build.FullCommand():
 		_, err = execBuild(hosts)
@@ -329,9 +329,10 @@ func execEval() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	ctx.EvalHosts(deploymentPath, attrkey)
 
-	return deployment, nil
+	path, err := ctx.EvalHosts(deploymentPath, attrkey)
+
+	return path, err
 }
 
 func execPush(hosts []nix.Host) (string, error) {

--- a/nix/nix.go
+++ b/nix/nix.go
@@ -176,7 +176,8 @@ func (ctx *NixContext) GetBuildShell(deploymentPath string) (buildShell *string,
 	return buildShell, nil
 }
 
-func (ctx *NixContext) EvalHosts(deploymentPath string, attribute string) {
+func (ctx *NixContext) EvalHosts(deploymentPath string, attr string) (string, error) {
+	attribute := "nodes." + attr
 	args := []string{ctx.EvalMachines,
 		"--arg", "networkExpr", deploymentPath,
 		"--eval", "--strict", "-A", attribute}
@@ -190,8 +191,8 @@ func (ctx *NixContext) EvalHosts(deploymentPath string, attribute string) {
 
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	cmd.Run()
-	// TODO: add error handling + finalizer(?)
+	err := cmd.Run()
+	return deploymentPath, err
 }
 
 func (ctx *NixContext) GetMachines(deploymentPath string) (deployment Deployment, err error) {

--- a/nix/nix.go
+++ b/nix/nix.go
@@ -176,6 +176,24 @@ func (ctx *NixContext) GetBuildShell(deploymentPath string) (buildShell *string,
 	return buildShell, nil
 }
 
+func (ctx *NixContext) EvalHosts(deploymentPath string, attribute string) {
+	args := []string{ctx.EvalMachines,
+		"--arg", "networkExpr", deploymentPath,
+		"--eval", "--strict", "-A", attribute}
+
+	cmd := exec.Command("nix-instantiate", args...)
+	utils.AddFinalizer(func() {
+		if (cmd.ProcessState == nil || !cmd.ProcessState.Exited()) && cmd.Process != nil {
+			_ = cmd.Process.Signal(syscall.SIGTERM)
+		}
+	})
+
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Run()
+	// TODO: add error handling + finalizer(?)
+}
+
 func (ctx *NixContext) GetMachines(deploymentPath string) (deployment Deployment, err error) {
 
 	args := []string{"--eval", ctx.EvalMachines,


### PR DESCRIPTION
used to inspect arbitrary attributes without building hosts.

switch clause with early return in main to avoid calling getHosts and spamming stdout. 