### PR TITLE
Add support for targetPort

### DIFF
--- a/data/eval-machines.nix
+++ b/data/eval-machines.nix
@@ -78,7 +78,7 @@ in rec {
 
     machines =
       flip mapAttrs nodes (n: v': let v = scrubOptionValue v'; in
-        { inherit (v.config.deployment) targetHost targetUser secrets healthChecks buildOnly substituteOnDestination tags;
+        { inherit (v.config.deployment) targetHost targetPort targetUser secrets healthChecks buildOnly substituteOnDestination tags;
           name = n;
           nixosRelease = v.config.system.nixos.release or (removeSuffix v.config.system.nixos.version.suffix v.config.system.nixos.version);
           nixConfig = mapAttrs

--- a/data/options.nix
+++ b/data/options.nix
@@ -176,6 +176,14 @@ in
       '';
     };
 
+    targetPort = mkOption {
+      type = nullOr int;
+      default = null;
+      description = ''
+        The port number of remote host used for deployment.
+      '';
+    };
+
     targetUser = mkOption {
       type = str;
       default = "";

--- a/healthchecks/types.go
+++ b/healthchecks/types.go
@@ -15,6 +15,7 @@ import (
 type Host interface {
 	GetName() string
 	GetTargetHost() string
+	GetTargetPort() int
 	GetTargetUser() string
 	GetHealthChecks() HealthChecks
 }

--- a/nix/nix.go
+++ b/nix/nix.go
@@ -25,6 +25,7 @@ type Host struct {
 	Name                    string
 	NixosRelease            string
 	TargetHost              string
+	TargetPort              int
 	TargetUser              string
 	Secrets                 map[string]secrets.Secret
 	BuildOnly               bool
@@ -64,6 +65,10 @@ func (host *Host) GetName() string {
 
 func (host *Host) GetTargetHost() string {
 	return host.TargetHost
+}
+
+func (host *Host) GetTargetPort() int {
+	return host.TargetPort
 }
 
 func (host *Host) GetTargetUser() string {
@@ -384,6 +389,9 @@ func Push(ctx *ssh.SSHContext, host Host, paths ...string) (err error) {
 	}
 	if ctx.SkipHostKeyCheck {
 		sshOpts = append(sshOpts, fmt.Sprintf("%s", "-o StrictHostkeyChecking=No -o UserKnownHostsFile=/dev/null"))
+	}
+	if host.TargetPort != 0 {
+		sshOpts = append(sshOpts, fmt.Sprintf("-p %d", host.TargetPort))
 	}
 	if ctx.ConfigFile != "" {
 		sshOpts = append(sshOpts, fmt.Sprintf("-F %s", ctx.ConfigFile))

--- a/ssh/ssh.go
+++ b/ssh/ssh.go
@@ -34,6 +34,7 @@ type Context interface {
 type Host interface {
 	GetName() string
 	GetTargetHost() string
+	GetTargetPort() int
 	GetTargetUser() string
 }
 
@@ -94,6 +95,17 @@ func (ctx *SSHContext) sshArgs(host Host, transfer *FileTransfer) (cmd string, a
 		args = append(args, "-F", ctx.ConfigFile)
 	}
 	var hostAndDestination = host.GetTargetHost()
+	if host.GetTargetPort() != 0 {
+		var optionName string
+		if transfer != nil {
+			optionName = "-P"
+		} else {
+			optionName = "-p"
+		}
+
+		args = append(args, optionName, fmt.Sprintf("%d", host.GetTargetPort()))
+	}
+
 	if transfer != nil {
 		args = append(args, transfer.Source)
 		hostAndDestination += ":" + transfer.Destination


### PR DESCRIPTION
Allow to specify remote info like this:

```nix
{
  deployment.targetHost = "11.11.11.11";
  deployment.targetUser = "deploy";
  deployment.targetPort = 8022;  # add this
}
```

Then:
+ there's no need to use `SSH_CONFIG_FILE` in a simple case which just specifies a non-standard port.

> I'm not an expect of Go. If you have any idea of the code, just change it. I'm ok with that. ;)