### PR TITLE
Don't require using a file to pass nodes to build a derivation with all the system in a grid.

### DIFF
--- a/data/eval-machines.nix
+++ b/data/eval-machines.nix
@@ -101,10 +101,22 @@ in rec {
   };
 
   # Phase 2: build complete machine configurations.
-  machines = { argsFile, buildTargets ? null }:
+  machines = {
+    argsFile ? null,
+    names ? null
+    buildTargets ? null
+  }:
+    assert argsFile != null -> names == null;
     let
-      fileArgs = builtins.fromJSON (builtins.readFile argsFile);
-      nodes' = filterAttrs (n: v: elem n fileArgs.Names) nodes; in
+      names' = if argsFile != null then
+          (builtins.fromJSON (builtins.readFile argsFile)).Names
+        else
+          names;
+      nodes' = if names != null then
+          filterAttrs (n: v: elem n fileArgs.Names) nodes
+        else
+          nodes;
+    in
     runCommand "morph"
       { preferLocalBuild = true; }
       (if buildTargets == null

--- a/data/eval-machines.nix
+++ b/data/eval-machines.nix
@@ -1,9 +1,9 @@
 # Completely stripped down version of nixops' evaluator
-{ networkExpr }:
+{ networkExpr, pkgs ? {} }:
 
 let
   network      = import networkExpr;
-  nwPkgs       = network.network.pkgs or {};
+  nwPkgs       = network.network.pkgs or pkgs;
   lib          = network.network.lib or nwPkgs.lib or (import <nixpkgs/lib>);
   evalConfig   = network.network.evalConfig or ((nwPkgs.path or <nixpkgs>) + "/nixos/lib/eval-config.nix");
   runCommand   = network.network.runCommand or nwPkgs.runCommand or ((import <nixpkgs> {}).runCommand);

--- a/data/eval-machines.nix
+++ b/data/eval-machines.nix
@@ -102,14 +102,14 @@ in rec {
 
   # Phase 2: build complete machine configurations.
   machines = {
-    argsFile ? null,
-    names ? null
-    buildTargets ? null
+    names ? null,
+    buildTargets ? null,
+    argsJSON ? null,
   }:
-    assert argsFile != null -> names == null;
+    assert argsJSON != null -> names == null;
     let
       names' = if argsFile != null then
-          (builtins.fromJSON (builtins.readFile argsFile)).Names
+          (builtins.fromJSON argsJSON).names
         else
           names;
       nodes' = if names != null then

--- a/default.nix
+++ b/default.nix
@@ -3,35 +3,41 @@
 , version ? "dev"
 }:
 
-pkgs.buildGoModule rec {
-  name = "morph-unstable-${version}";
-  inherit version;
+let
+  morph = pkgs.buildGoModule rec {
+    name = "morph-unstable-${version}";
+    inherit version;
 
-  nativeBuildInputs = with pkgs; [ go-bindata ];
+    nativeBuildInputs = with pkgs; [ go-bindata ];
 
-  src = pkgs.nix-gitignore.gitignoreSource [] ./.;
+    src = pkgs.nix-gitignore.gitignoreSource [] ./.;
 
-  buildFlagsArray = ''
-    -ldflags=
-    -X
-    main.version=${version}
-  '';
+    buildFlagsArray = ''
+      -ldflags=
+      -X
+      main.version=${version}
+    '';
 
-  vendorSha256 = "08zzp0h4c4i5hk4whz06a3da7qjms6lr36596vxz0d8q0n7rspr9";
+    vendorSha256 = "08zzp0h4c4i5hk4whz06a3da7qjms6lr36596vxz0d8q0n7rspr9";
 
-  postPatch = ''
-    go-bindata -pkg assets -o assets/assets.go data/
-  '';
+    postPatch = ''
+      go-bindata -pkg assets -o assets/assets.go data/
+    '';
 
-  postInstall = ''
-    mkdir -p $lib
-    cp -v ./data/*.nix $lib
-  '';
+    postInstall = ''
+      mkdir -p $lib
+      cp -v ./data/*.nix $lib
+    '';
 
-  outputs = [ "out" "lib" ];
+    outputs = [ "out" "lib" ];
 
-  meta = {
-    homepage = "https://github.com/DBCDK/morph";
-    description = "Morph is a NixOS host manager written in Golang.";
+    passthru = {
+      eval = args@{...}: (import (morph.lib + "/eval-machines.nix")) ({ inherit pkgs; } // args);
+    };
+
+    meta = {
+      homepage = "https://github.com/DBCDK/morph";
+      description = "Morph is a NixOS host manager written in Golang.";
+    };
   };
-}
+in morph

--- a/nix/nix.go
+++ b/nix/nix.go
@@ -54,8 +54,8 @@ type NixContext struct {
 	AllowBuildShell bool
 }
 
-type FileArgs struct {
-	Names []string
+type JSONArgs struct {
+	Names []string `json:"names"`
 }
 
 func (host *Host) GetName() string {
@@ -228,17 +228,9 @@ func (ctx *NixContext) BuildMachines(deploymentPath string, hosts []Host, nixArg
 		hostsArg = append(hostsArg, host.Name)
 	}
 
-	fileArgs := FileArgs{
+	jsonArgs, err := json.Marshal(JSONArgs{
 		Names: hostsArg,
-	}
-
-	jsonArgs, err := json.Marshal(fileArgs)
-	if err != nil {
-		return "", err
-	}
-	argsFile := tmpdir + "/morph-args.json"
-
-	err = ioutil.WriteFile(argsFile, jsonArgs, 0644)
+	})
 	if err != nil {
 		return "", err
 	}
@@ -259,7 +251,7 @@ func (ctx *NixContext) BuildMachines(deploymentPath string, hosts []Host, nixArg
 		"-f", ctx.EvalMachines,
 		"-v",
 		"--arg", "networkExpr", deploymentPath,
-		"--argstr", "argsFile", argsFile,
+		"--argstr", "argsJSON", string(jsonArgs),
 		"--out-link", resultLinkPath,
 		"machines",
 	}


### PR DESCRIPTION
Based on #166.

This adds a new argument to `machine`, which is the list of node names to build. This also changes `argsFile` to `argsJSON`, for passing the list of node names from go to nix without needing to write a file to disk.