### PR TITLE
Examples use primary nixpkgs

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ Example deployments can be found in the `examples` directory, and built as follo
 ```
 $ morph build examples/simple.nix
 Selected 2/2 hosts (name filter:-0, limits:-0):
-	  0: db01.example.com (secrets: 0, health checks: 0)
-	  1: web01.example.com (secrets: 0, health checks: 0)
+	  0: db01 (secrets: 0, health checks: 0)
+	  1: web01 (secrets: 0, health checks: 0)
 
 <probably lots of nix-build output>
 

--- a/examples/healthchecks.nix
+++ b/examples/healthchecks.nix
@@ -1,9 +1,5 @@
 let
-  # Pin the deployment package-set to a specific version of nixpkgs
-  pkgs = import (builtins.fetchTarball {
-    url = "https://github.com/NixOS/nixpkgs-channels/archive/51d115ac89d676345b05a0694b23bd2691bf708a.tar.gz";
-    sha256 = "1gfjaa25nq4vprs13h30wasjxh79i67jj28v54lkj4ilqjhgh2rs";
-  }) {};
+  pkgs = import (import ../nixpkgs.nix) {};
 in
 {
   network =  {

--- a/examples/healthchecks.nix
+++ b/examples/healthchecks.nix
@@ -7,7 +7,7 @@ in
     description = "health check demo hosts";
   };
 
-  "web01.example.com" = { config, pkgs, ... }: {
+  "web01" = { config, pkgs, ... }: {
     boot.loader.systemd-boot.enable = true;
     boot.loader.efi.canTouchEfiVariables = true;
 

--- a/examples/secrets.nix
+++ b/examples/secrets.nix
@@ -1,9 +1,5 @@
 let
-  # Pin the deployment package-set to a specific version of nixpkgs
-  pkgs = import (builtins.fetchTarball {
-    url = "https://github.com/NixOS/nixpkgs-channels/archive/51d115ac89d676345b05a0694b23bd2691bf708a.tar.gz";
-    sha256 = "1gfjaa25nq4vprs13h30wasjxh79i67jj28v54lkj4ilqjhgh2rs";
-  }) {};
+  pkgs = import (import ../nixpkgs.nix) {};
 in
 {
   network =  {

--- a/examples/secrets.nix
+++ b/examples/secrets.nix
@@ -7,7 +7,7 @@ in
     description = "webserver with secrets";
   };
 
-  "web01.example.com" = { config, pkgs, ... }: {
+  "web01" = { config, pkgs, ... }: {
     deployment = {
       secrets = {
         "nix-cache-signing-key" = {

--- a/examples/simple.nix
+++ b/examples/simple.nix
@@ -10,7 +10,7 @@ in
     };
   };
 
-  "web01.example.com" = { config, pkgs, ... }: {
+  "web01" = { config, pkgs, ... }: {
     deployment.tags = [ "web" ];
 
     boot.loader.systemd-boot.enable = true;
@@ -24,7 +24,7 @@ in
     };
   };
 
-  "db01.example.com" = { config, pkgs, ... }: {
+  "db01" = { config, pkgs, ... }: {
     deployment.tags = [ "db" ];
 
     boot.loader.systemd-boot.enable = true;

--- a/examples/simple.nix
+++ b/examples/simple.nix
@@ -1,9 +1,5 @@
 let
-  # Pin the deployment package-set to a specific version of nixpkgs
-  pkgs = import (builtins.fetchTarball {
-    url = "https://github.com/NixOS/nixpkgs-channels/archive/51d115ac89d676345b05a0694b23bd2691bf708a.tar.gz";
-    sha256 = "1gfjaa25nq4vprs13h30wasjxh79i67jj28v54lkj4ilqjhgh2rs";
-  }) {};
+  pkgs = import (import ../nixpkgs.nix) {};
 in
 {
   network =  {


### PR DESCRIPTION
To actually stay reasonably up-to-date with nixpkgs proper. We didn't notice the problem with eval-machines extraArgs deprecation because we didn't follow a recent nixpkgs.