### PR TITLE
eval-machines: support `specialArgs`

### DIFF
--- a/data/eval-machines.nix
+++ b/data/eval-machines.nix
@@ -6,7 +6,12 @@ let
   nw             = network.network;
   nwPkgs         = nw.pkgs or {};
   nwLib          = nw.lib or nwPkgs.lib or (import <nixpkgs/lib>);
-  nwEvalConfig   = nw.evalConfig or ((nwPkgs.path or <nixpkgs>) + "/nixos/lib/eval-config.nix");
+  nwEvalConfig   = let
+                     nwEvalConfig' =
+                       nw.evalConfig or ((nwPkgs.path or <nixpkgs>) + "/nixos/lib/eval-config.nix");
+                   in
+                   if nwLib.isFunction nwEvalConfig' then nwEvalConfig' else import nwEvalConfig';
+  nwSpecialArgs  = nw.specialArgs or {};
   nwRunCommand   = nw.runCommand or nwPkgs.runCommand or ((import <nixpkgs> {}).runCommand);
 in
 
@@ -56,6 +61,7 @@ in rec {
         check = false;
         nodes = uncheckedNodes;
       };
+      specialArgs = nwSpecialArgs;
     }) networkMachines;
 
   # Compute the definitions of the machines.
@@ -66,6 +72,7 @@ in rec {
         check = true;
         nodes = uncheckedNodes;
       };
+      specialArgs = nwSpecialArgs;
     }) networkMachines;
 
   deploymentInfoModule = {

--- a/data/options.nix
+++ b/data/options.nix
@@ -1,9 +1,9 @@
 { config, lib, pkgs, ... }:
 
-with lib;
-with lib.types;
-
 let
+
+inherit (lib) mkOption types;
+inherit (types) attrsOf bool enum int path listOf nullOr str submodule;
 
 ownerOptionsType = submodule ({ ... }: {
     options = {
@@ -91,7 +91,7 @@ healthCheckType = submodule ({ ... }: {
   };
 });
 
-httpHealthCheckType = types.submodule ({ ... }: {
+httpHealthCheckType = submodule ({ ... }: {
   options = {
     description = mkOption {
         type = str;
@@ -140,7 +140,7 @@ httpHealthCheckType = types.submodule ({ ... }: {
   };
 });
 
-cmdHealthCheckType = types.submodule ({ ... }: {
+cmdHealthCheckType = submodule ({ ... }: {
   options = {
     description = mkOption {
         type = str;
@@ -255,7 +255,7 @@ in
   # all derived dependencies.
   config.system.extraDependencies =
   let
-    cmds = concatMap (h: h.cmd) config.deployment.healthChecks.cmd;
+    cmds = builtins.concatMap (h: h.cmd) config.deployment.healthChecks.cmd;
   in
-  [ (pkgs.writeText "healthcheck-commands.txt" (concatStringsSep "\n" cmds)) ];
+  [ (pkgs.writeText "healthcheck-commands.txt" (builtins.concatStringsSep "\n" cmds)) ];
 }


### PR DESCRIPTION
Also, users can supply a function for `network.evalConfig` instead of just a path, if desired.