### PR TITLE
structured nix invocation args

### DIFF
--- a/nix/nix.go
+++ b/nix/nix.go
@@ -55,8 +55,80 @@ type NixContext struct {
 	AllowBuildShell bool
 }
 
-type FileArgs struct {
+type NixBuildInvocationArgs struct {
+	ArgsFile string
+	Attr string
+	DeploymentPath string
 	Names []string
+	NixArgs []string
+	NixBuildTargets string
+	NixConfig map[string]string
+	NixContext NixContext
+	ResultLinkPath string
+}
+
+func (nArgs *NixBuildInvocationArgs) ToNixBuildArgs() []string {
+	args := []string{
+		nArgs.NixContext.EvalMachines,
+		"--arg", "networkExpr", nArgs.DeploymentPath,
+		"--argstr", "argsFile", nArgs.ArgsFile,
+		"--out-link", nArgs.ResultLinkPath,
+		"--attr", nArgs.Attr,
+	}
+
+	args = append(args, mkOptions(nArgs.NixConfig)...)
+
+	if len(nArgs.NixArgs) > 0 {
+		args = append(args, nArgs.NixArgs...)
+	}
+
+	if nArgs.NixContext.ShowTrace {
+		args = append(args, "--show-trace")
+	}
+
+	if nArgs.NixBuildTargets != "" {
+		args = append(args,
+			"--arg", "buildTargets", nArgs.NixBuildTargets)
+	}
+
+	return args
+}
+
+func (nArgs *NixEvalInvocationArgs) ToNixInstantiateArgs() []string {
+	args := []string{
+		"--eval", nArgs.NixContext.EvalMachines,
+		"--arg", "networkExpr", nArgs.DeploymentPath,
+		"--argstr", "argsFile", nArgs.ArgsFile,
+		"--attr", nArgs.Attr,
+	}
+
+	if nArgs.NixContext.ShowTrace {
+		args = append(args, "--show-trace")
+	}
+
+	if nArgs.AsJSON {
+		args = append(args, "--json")
+	}
+
+	if nArgs.Strict {
+		args = append(args, "--strict")
+	}
+
+	if nArgs.ReadWriteMode {
+		args = append(args, "--read-write-mode")
+	}
+
+	return args
+}
+
+type NixEvalInvocationArgs struct {
+	AsJSON bool
+	ArgsFile string
+	Attr string
+	DeploymentPath string
+	NixContext NixContext
+	Strict bool
+	ReadWriteMode bool
 }
 
 func (host *Host) GetName() string {
@@ -145,16 +217,21 @@ func (host *Host) Reboot(sshContext *ssh.SSHContext) error {
 
 func (ctx *NixContext) GetBuildShell(deploymentPath string) (buildShell *string, err error) {
 
-	args := []string{"--eval", ctx.EvalMachines,
-		"--attr", "info.buildShell",
-		"--arg", "networkExpr", deploymentPath,
-		"--json", "--strict", "--read-write-mode"}
-
-	if ctx.ShowTrace {
-		args = append(args, "--show-trace")
+	nixEvalInvocationArgs := NixEvalInvocationArgs{
+		AsJSON: true,
+		Attr: "info.buildShell",
+		DeploymentPath: deploymentPath,
+		NixContext: *ctx,
+		Strict: true,
 	}
 
-	cmd := exec.Command("nix-instantiate", args...)
+	jsonArgs, err := json.Marshal(nixEvalInvocationArgs)
+	if err != nil {
+		return buildShell, err
+	}
+
+	cmd := exec.Command("nix-instantiate", nixEvalInvocationArgs.ToNixInstantiateArgs()...)
+
 
 	var stdout bytes.Buffer
 	cmd.Stdout = &stdout
@@ -165,6 +242,8 @@ func (ctx *NixContext) GetBuildShell(deploymentPath string) (buildShell *string,
 			_ = cmd.Process.Signal(syscall.SIGTERM)
 		}
 	})
+	cmd.Env = os.Environ()
+	cmd.Env = append(cmd.Env, fmt.Sprintf("MORPH_ARGS=%s", jsonArgs))
 	err = cmd.Run()
 	if err != nil {
 		errorMessage := fmt.Sprintf(
@@ -183,11 +262,21 @@ func (ctx *NixContext) GetBuildShell(deploymentPath string) (buildShell *string,
 
 func (ctx *NixContext) EvalHosts(deploymentPath string, attr string) (string, error) {
 	attribute := "nodes." + attr
-	args := []string{ctx.EvalMachines,
-		"--arg", "networkExpr", deploymentPath,
-		"--eval", "--strict", "-A", attribute}
 
-	cmd := exec.Command("nix-instantiate", args...)
+	nixEvalInvocationArgs := NixEvalInvocationArgs{
+		AsJSON: false,
+		Attr: attribute,
+		DeploymentPath: deploymentPath,
+		NixContext: *ctx,
+		Strict: true,
+	}
+
+	jsonArgs, err := json.Marshal(nixEvalInvocationArgs)
+	if err != nil {
+		return "", err
+	}
+
+	cmd := exec.Command("nix-instantiate", nixEvalInvocationArgs.ToNixInstantiateArgs()...)
 	utils.AddFinalizer(func() {
 		if (cmd.ProcessState == nil || !cmd.ProcessState.Exited()) && cmd.Process != nil {
 			_ = cmd.Process.Signal(syscall.SIGTERM)
@@ -196,22 +285,28 @@ func (ctx *NixContext) EvalHosts(deploymentPath string, attr string) (string, er
 
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	err := cmd.Run()
+	cmd.Env = os.Environ()
+	cmd.Env = append(cmd.Env, fmt.Sprintf("MORPH_ARGS=%s", jsonArgs))
+	err = cmd.Run()
 	return deploymentPath, err
 }
 
 func (ctx *NixContext) GetMachines(deploymentPath string) (deployment Deployment, err error) {
 
-	args := []string{"--eval", ctx.EvalMachines,
-		"--attr", "info.deployment",
-		"--arg", "networkExpr", deploymentPath,
-		"--json", "--strict"}
-
-	if ctx.ShowTrace {
-		args = append(args, "--show-trace")
+	nixEvalInvocationArgs := NixEvalInvocationArgs{
+		AsJSON: true,
+		Attr: "info.deployment",
+		DeploymentPath: deploymentPath,
+		NixContext: *ctx,
+		Strict: true,
 	}
 
-	cmd := exec.Command("nix-instantiate", args...)
+	jsonArgs, err := json.Marshal(nixEvalInvocationArgs)
+	if err != nil {
+		return deployment, err
+	}
+
+	cmd := exec.Command("nix-instantiate", nixEvalInvocationArgs.ToNixInstantiateArgs()...)
 
 	var stdout bytes.Buffer
 	cmd.Stdout = &stdout
@@ -222,6 +317,8 @@ func (ctx *NixContext) GetMachines(deploymentPath string) (deployment Deployment
 			_ = cmd.Process.Signal(syscall.SIGTERM)
 		}
 	})
+	cmd.Env = os.Environ()
+	cmd.Env = append(cmd.Env, fmt.Sprintf("MORPH_ARGS=%s", jsonArgs))
 	err = cmd.Run()
 	if err != nil {
 		errorMessage := fmt.Sprintf(
@@ -247,24 +344,9 @@ func (ctx *NixContext) BuildMachines(deploymentPath string, hosts []Host, nixArg
 		os.RemoveAll(tmpdir)
 	})
 
-	hostsArg := []string{}
+	hostNames := []string{}
 	for _, host := range hosts {
-		hostsArg = append(hostsArg, host.Name)
-	}
-
-	fileArgs := FileArgs{
-		Names: hostsArg,
-	}
-
-	jsonArgs, err := json.Marshal(fileArgs)
-	if err != nil {
-		return "", err
-	}
-	argsFile := tmpdir + "/morph-args.json"
-
-	err = ioutil.WriteFile(argsFile, jsonArgs, 0644)
-	if err != nil {
-		return "", err
+		hostNames = append(hostNames, host.Name)
 	}
 
 	resultLinkPath := filepath.Join(path.Dir(deploymentPath), ".gcroots", path.Base(deploymentPath))
@@ -278,28 +360,6 @@ func (ctx *NixContext) BuildMachines(deploymentPath string, hosts []Host, nixArg
 		// create tmp dir for result link
 		resultLinkPath = filepath.Join(tmpdir, "result")
 	}
-	args := []string{
-		ctx.EvalMachines,
-		"--arg", "networkExpr", deploymentPath,
-		"--argstr", "argsFile", argsFile,
-		"--out-link", resultLinkPath,
-		"--attr", "machines",
-	}
-
-	args = append(args, mkOptions(hosts[0])...)
-
-	if len(nixArgs) > 0 {
-		args = append(args, nixArgs...)
-	}
-
-	if ctx.ShowTrace {
-		args = append(args, "--show-trace")
-	}
-
-	if nixBuildTargets != "" {
-		args = append(args,
-			"--arg", "buildTargets", nixBuildTargets)
-	}
 
 	buildShell, err := ctx.GetBuildShell(deploymentPath)
 
@@ -310,12 +370,36 @@ func (ctx *NixContext) BuildMachines(deploymentPath string, hosts []Host, nixArg
 		return resultPath, errors.New(errorMessage)
 	}
 
+	argsFile := tmpdir + "/morph-args.json"
+	NixBuildInvocationArgs := NixBuildInvocationArgs{
+		ArgsFile: argsFile,
+		Attr: "machines",
+		DeploymentPath: deploymentPath,
+		Names: hostNames,
+		NixArgs: nixArgs,
+		NixBuildTargets: nixBuildTargets,
+		NixConfig: hosts[0].NixConfig,
+		NixContext: *ctx,
+		ResultLinkPath: resultLinkPath,
+	}
+
+	jsonArgs, err := json.Marshal(NixBuildInvocationArgs)
+	if err != nil {
+		return "", err
+	}
+
+	err = ioutil.WriteFile(argsFile, jsonArgs, 0644)
+	if err != nil {
+		return "", err
+	}
+
+
 	var cmd *exec.Cmd
 	if ctx.AllowBuildShell && buildShell != nil {
-		shellArgs := strings.Join(append([]string{"nix-build"}, args...), " ")
+		shellArgs := strings.Join(append([]string{"nix-build"}, NixBuildInvocationArgs.ToNixBuildArgs()...), " ")
 		cmd = exec.Command("nix-shell", *buildShell, "--pure", "--run", shellArgs)
 	} else {
-		cmd = exec.Command("nix-build", args...)
+		cmd = exec.Command("nix-build", NixBuildInvocationArgs.ToNixBuildArgs()...)
 	}
 
 	// show process output on attached stdout/stderr
@@ -326,6 +410,10 @@ func (ctx *NixContext) BuildMachines(deploymentPath string, hosts []Host, nixArg
 			_ = cmd.Process.Signal(syscall.SIGTERM)
 		}
 	})
+
+	cmd.Env = os.Environ()
+	cmd.Env = append(cmd.Env, fmt.Sprintf("MORPH_ARGS=%s", jsonArgs))
+	cmd.Env = append(cmd.Env, fmt.Sprintf("MORPH_ARGS_FILE=%s", argsFile))
 	err = cmd.Run()
 
 	if err != nil {
@@ -343,9 +431,13 @@ func (ctx *NixContext) BuildMachines(deploymentPath string, hosts []Host, nixArg
 	return
 }
 
-func mkOptions(host Host) []string {
+func mkOptionsFromHost(host Host) []string {
+	return mkOptions(host.NixConfig)
+}
+
+func mkOptions(nixConfig map[string]string) []string {
 	var options = make([]string, 0)
-	for k, v := range host.NixConfig {
+	for k, v := range nixConfig {
 		options = append(options, "--option")
 		options = append(options, k)
 		options = append(options, v)
@@ -400,7 +492,7 @@ func Push(ctx *ssh.SSHContext, host Host, paths ...string) (err error) {
 		env = append(env, fmt.Sprintf("NIX_SSHOPTS=%s", strings.Join(sshOpts, " ")))
 	}
 
-	options := mkOptions(host)
+	options := mkOptionsFromHost(host)
 	for _, path := range paths {
 		args := []string{
 			"--to", userArg + host.TargetHost + keyArg,


### PR DESCRIPTION
**Motivation:**

Make it easier to hook into the eval and build processes of morph without destroying morph completely. Currently, it's difficult, due to unstructured args given to nix-instatiate and nix-build respectively. Even though you can wrap these commands and put them on morph PATH, you'd have to build a nix CLI command line parser in order to reverse engineer what was the original intend of morph.i

As an extra bonus, with this change, it'll become easier to switch Nix CLIs from `nix-build` to `nix build` later, since logical "morph-intent" is separated from the "ToCLIArgs()" implementation.

*nix-copy-closure* (Push) have been scoped out and left unchanged. Let me know if we should chane ge this.

**Implementation**

Everywhere we run `nix-instatiate` or `nix-build`, expose a json map in an environment variable containing all the args we supply to the Nix CLI commands. E.g. `echo $MORPH_ARGS | jq` would give something like:

```json
{
  "ArgsFile": "/run/user/1000/morph-3675721930/morph-args.json",
  "Attr": "machines",
  "DeploymentPath": "/home/johanot/work/project/deploy.nix",
  "Names": [
    "host-1",
    "host-2",
    "host-3"
  ],
  "NixArgs": null,
  "NixBuildTargets": "",
  "NixConfig": null,
  "NixContext": {
    "EvalMachines": "/nix/store/0q404b6p1anmmanpf8hnasi9wq7wgfaj-morph-unstable-dev-lib/eval-machines.nix",
    "ShowTrace": false,
    "KeepGCRoot": false,
    "AllowBuildShell": false
  },
  "ResultLinkPath": "/run/user/1000/morph-3675721930/result"
}
```

In the special case of `nix-build`, this JSON map is also written to a file beside the env var. The file can be read by the buildShell.

**Example usecase**

Make morph a simple flake deployer:

https://gist.github.com/johanot/f8ac86b16d38234b8b34f1242e1a2183