### PR TITLE
Allow override of nix commands and eval-machines with env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,10 @@ Morph supports the following (optional) environment variables:
 - `SSH_USER` specifies the user that should be used to connect to the remote system
 - `SSH_SKIP_HOST_KEY_CHECK` if set disables host key verification
 - `SSH_CONFIG_FILE` allows to change the location of the ~/.ssh/config file
+- `MORPH_NIX_EVAL_CMD` morph will invoke this command instead of default: "nix-instantiate" on PATH 
+- `MORPH_NIX_BUILD_CMD` morph will invoke this command instead of default: "nix-build" on PATH 
+- `MORPH_NIX_SHELL_CMD` morph will invoke this command instead of default: "nix-shell" on PATH
+- `MORPH_NIX_EVAL_MACHINES` path to a custom eval-machines.nix. Defaults to the eval-machines.nix bundled with morph
 
 ### Secrets
 

--- a/morph.go
+++ b/morph.go
@@ -583,8 +583,29 @@ func getHosts(deploymentPath string) (hosts []nix.Host, err error) {
 }
 
 func getNixContext() *nix.NixContext {
+	evalCmd := os.Getenv("MORPH_NIX_EVAL_CMD")
+	buildCmd := os.Getenv("MORPH_NIX_BUILD_CMD")
+	shellCmd := os.Getenv("MORPH_NIX_SHELL_CMD")
+	evalMachines := os.Getenv("MORPH_NIX_EVAL_MACHINES")
+
+	if evalCmd == "" {
+		evalCmd = "nix-instantiate"
+	}
+	if buildCmd == "" {
+		buildCmd = "nix-build"
+	}
+	if shellCmd == "" {
+		shellCmd = "nix-shell"
+	}
+	if evalMachines == "" {
+		evalMachines = filepath.Join(assetRoot, "eval-machines.nix")
+	}
+
 	return &nix.NixContext{
-		EvalMachines:    filepath.Join(assetRoot, "eval-machines.nix"),
+		EvalCmd: evalCmd,
+		BuildCmd: buildCmd,
+		ShellCmd: shellCmd,
+		EvalMachines:    evalMachines,
 		ShowTrace:       showTrace,
 		KeepGCRoot:      *keepGCRoot,
 		AllowBuildShell: *allowBuildShell,


### PR DESCRIPTION
This desired effect, for the nix commands, could probably be achieved by wrapping, but this makes it easier if you wanna conserve the original nix tools.

This PR makes extra sense in the light of #199 

*nix-copy-closure* (Push) have been scoped out and left unchanged.