### PR TITLE
evalConfig: Ensure system is null for eval-config

### DIFF
--- a/data/eval-machines.nix
+++ b/data/eval-machines.nix
@@ -53,6 +53,8 @@ in rec {
     listToAttrs (map (machineName:
       { name = machineName;
         value = import evalConfig {
+          # Force decide system in module system
+          system = null;
           modules = modules {
             inherit machineName;
             check = false;
@@ -67,6 +69,8 @@ in rec {
     listToAttrs (map (machineName:
       { name = machineName;
         value = import evalConfig {
+          # Force decide system in module system
+          system = null;
           modules = modules {
             inherit machineName;
             check = true;


### PR DESCRIPTION
Otherwise we get failures in hermetic builds where builtins.currentSystem does not exist

See https://github.com/NixOS/nixpkgs/commit/693e2c32871dcea7fe2ef455ee77571d3a117499 for the change that made this necessary