### PR TITLE
Add SSH_ARGS environment variable

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -9,7 +9,7 @@ pkgs.buildGoModule rec {
   ldflags =
     [ "-X main.version=${version}" "-X main.assetRoot=${placeholder "lib"}" ];
 
-  vendorHash = "sha256-zQlMtbXgrH83zrcIoOuFhb2tYCeQ1pz4UQUvRIsLMCE==";
+  vendorHash = "sha256-2zy8ejm8yRbAXEHNKIgelVaLCa+hfvO56AMithsFSRU=";
 
   postInstall = ''
     mkdir -p $lib

--- a/flake.nix
+++ b/flake.nix
@@ -70,7 +70,7 @@
               "-X main.assetRoot=${placeholder "lib"}"
             ];
 
-            vendorHash = "sha256-zQlMtbXgrH83zrcIoOuFhb2tYCeQ1pz4UQUvRIsLMCE==";
+            vendorHash = "sha256-2zy8ejm8yRbAXEHNKIgelVaLCa+hfvO56AMithsFSRU=";
 
             postInstall = ''
               mkdir -p $lib

--- a/go.mod
+++ b/go.mod
@@ -13,5 +13,6 @@ require (
 	github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137 // indirect
 	golang.org/x/sys v0.15.0 // indirect
 	golang.org/x/term v0.15.0 // indirect
+	github.com/frioux/shellquote v0.0.2 // indirect
 	gopkg.in/mattes/go-expand-tilde.v1 v1.0.0-20150330173918-cb884138e64c // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,10 @@ github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137 h1:s6gZFSlWYmbqAu
 github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137/go.mod h1:OMCwj8VM1Kc9e19TLln2VL61YJF0x1XFtfdL4JdbSyE=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/frioux/shellquote v0.0.2 h1:CvQ1aMCS/xhhyGF4JIeA49bhE3W1s5XdBkwmhH3BceQ=
+github.com/frioux/shellquote v0.0.2/go.mod h1:1VoFO5LSUNqwAKp2QjSpf9b4PZ4ff+uKXPEjonuyJh8=
 github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
 github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/morph.go
+++ b/morph.go
@@ -444,6 +444,7 @@ func createSSHContext() *ssh.SSHContext {
 		DefaultUsername:    os.Getenv("SSH_USER"),
 		SkipHostKeyCheck:   os.Getenv("SSH_SKIP_HOST_KEY_CHECK") != "",
 		ConfigFile:         os.Getenv("SSH_CONFIG_FILE"),
+		SshArgs:            os.Getenv("SSH_ARGS"),
 	}
 }
 

--- a/nix/nix.go
+++ b/nix/nix.go
@@ -18,6 +18,7 @@ import (
 	"github.com/DBCDK/morph/secrets"
 	"github.com/DBCDK/morph/ssh"
 	"github.com/DBCDK/morph/utils"
+	"github.com/frioux/shellquote"
 )
 
 type Host struct {
@@ -495,6 +496,13 @@ func Push(ctx *ssh.SSHContext, host Host, paths ...string) (err error) {
 	}
 	if ctx.ConfigFile != "" {
 		sshOpts = append(sshOpts, fmt.Sprintf("-F %s", ctx.ConfigFile))
+	}
+	if ctx.SshArgs != "" {
+		quotedArgs, err := shellquote.Quote(strings.Fields(ctx.SshArgs))
+		sshOpts = append(sshOpts, quotedArgs)
+		if err != nil {
+			return err
+		}
 	}
 	if len(sshOpts) > 0 {
 		env = append(env, fmt.Sprintf("NIX_SSHOPTS=%s", strings.Join(sshOpts, " ")))


### PR DESCRIPTION
This variable allows users to specify other custom arguments to be used with ssh and scp. This allows users to take advantage of more advanced ssh features like ControlPath, which could be used to fix #102 among other things.