### PR TITLE
enable gofmt, format code, fix `nix-command` by adding mainProgram

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -26,3 +26,6 @@
 
 # treewide nix fmt after flakification
 4a3684b18388d727f36a72f736f68ef379dbb209
+
+# treewide nix fmt with gofmt enabled
+7a77a23891d599c21a07ebe31a490d00fb835559

--- a/filter/filter.go
+++ b/filter/filter.go
@@ -56,7 +56,7 @@ func FilterHostsTags(allHosts []nix.Host, selectedTags []string) (hosts []nix.Ho
 		include := true
 		for _, selectTag := range selectedTags {
 			if !hasTag(host, selectTag) {
-				include = false;
+				include = false
 				break
 			}
 

--- a/flake.nix
+++ b/flake.nix
@@ -82,6 +82,7 @@
             meta = {
               homepage = "https://github.com/DBCDK/morph";
               description = "Morph is a NixOS host manager written in Golang.";
+              mainProgram = "morph";
             };
           };
         };

--- a/nix/nix.go
+++ b/nix/nix.go
@@ -49,9 +49,9 @@ type Deployment struct {
 }
 
 type NixContext struct {
-	EvalCmd	string
-	BuildCmd string
-	ShellCmd string
+	EvalCmd         string
+	BuildCmd        string
+	ShellCmd        string
 	EvalMachines    string
 	ShowTrace       bool
 	KeepGCRoot      bool
@@ -59,15 +59,15 @@ type NixContext struct {
 }
 
 type NixBuildInvocationArgs struct {
-	ArgsFile string
-	Attr string
-	DeploymentPath string
-	Names []string
-	NixArgs []string
+	ArgsFile        string
+	Attr            string
+	DeploymentPath  string
+	Names           []string
+	NixArgs         []string
 	NixBuildTargets string
-	NixConfig map[string]string
-	NixContext NixContext
-	ResultLinkPath string
+	NixConfig       map[string]string
+	NixContext      NixContext
+	ResultLinkPath  string
 }
 
 func (nArgs *NixBuildInvocationArgs) ToNixBuildArgs() []string {
@@ -125,13 +125,13 @@ func (nArgs *NixEvalInvocationArgs) ToNixInstantiateArgs() []string {
 }
 
 type NixEvalInvocationArgs struct {
-	AsJSON bool
-	ArgsFile string
-	Attr string
+	AsJSON         bool
+	ArgsFile       string
+	Attr           string
 	DeploymentPath string
-	NixContext NixContext
-	Strict bool
-	ReadWriteMode bool
+	NixContext     NixContext
+	Strict         bool
+	ReadWriteMode  bool
 }
 
 func (host *Host) GetName() string {
@@ -221,18 +221,17 @@ func (host *Host) Reboot(sshContext *ssh.SSHContext) error {
 func (ctx *NixContext) GetBuildShell(deploymentPath string) (buildShell *string, err error) {
 
 	nixEvalInvocationArgs := NixEvalInvocationArgs{
-		AsJSON: true,
-		Attr: "info.buildShell",
+		AsJSON:         true,
+		Attr:           "info.buildShell",
 		DeploymentPath: deploymentPath,
-		NixContext: *ctx,
-		Strict: true,
+		NixContext:     *ctx,
+		Strict:         true,
 	}
 
 	jsonArgs, err := json.Marshal(nixEvalInvocationArgs)
 	if err != nil {
 		return buildShell, err
 	}
-
 
 	cmd := exec.Command(ctx.EvalCmd, nixEvalInvocationArgs.ToNixInstantiateArgs()...)
 
@@ -266,13 +265,12 @@ func (ctx *NixContext) GetBuildShell(deploymentPath string) (buildShell *string,
 func (ctx *NixContext) EvalHosts(deploymentPath string, attr string) (string, error) {
 	attribute := "nodes." + attr
 
-
 	nixEvalInvocationArgs := NixEvalInvocationArgs{
-		AsJSON: false,
-		Attr: attribute,
+		AsJSON:         false,
+		Attr:           attribute,
 		DeploymentPath: deploymentPath,
-		NixContext: *ctx,
-		Strict: true,
+		NixContext:     *ctx,
+		Strict:         true,
 	}
 
 	jsonArgs, err := json.Marshal(nixEvalInvocationArgs)
@@ -299,18 +297,17 @@ func (ctx *NixContext) EvalHosts(deploymentPath string, attr string) (string, er
 func (ctx *NixContext) GetMachines(deploymentPath string) (deployment Deployment, err error) {
 
 	nixEvalInvocationArgs := NixEvalInvocationArgs{
-		AsJSON: true,
-		Attr: "info.deployment",
+		AsJSON:         true,
+		Attr:           "info.deployment",
 		DeploymentPath: deploymentPath,
-		NixContext: *ctx,
-		Strict: true,
+		NixContext:     *ctx,
+		Strict:         true,
 	}
 
 	jsonArgs, err := json.Marshal(nixEvalInvocationArgs)
 	if err != nil {
 		return deployment, err
 	}
-
 
 	cmd := exec.Command(ctx.EvalCmd, nixEvalInvocationArgs.ToNixInstantiateArgs()...)
 
@@ -378,15 +375,15 @@ func (ctx *NixContext) BuildMachines(deploymentPath string, hosts []Host, nixArg
 
 	argsFile := tmpdir + "/morph-args.json"
 	NixBuildInvocationArgs := NixBuildInvocationArgs{
-		ArgsFile: argsFile,
-		Attr: "machines",
-		DeploymentPath: deploymentPath,
-		Names: hostNames,
-		NixArgs: nixArgs,
+		ArgsFile:        argsFile,
+		Attr:            "machines",
+		DeploymentPath:  deploymentPath,
+		Names:           hostNames,
+		NixArgs:         nixArgs,
 		NixBuildTargets: nixBuildTargets,
-		NixConfig: hosts[0].NixConfig,
-		NixContext: *ctx,
-		ResultLinkPath: resultLinkPath,
+		NixConfig:       hosts[0].NixConfig,
+		NixContext:      *ctx,
+		ResultLinkPath:  resultLinkPath,
 	}
 
 	jsonArgs, err := json.Marshal(NixBuildInvocationArgs)
@@ -398,7 +395,6 @@ func (ctx *NixContext) BuildMachines(deploymentPath string, hosts []Host, nixArg
 	if err != nil {
 		return "", err
 	}
-
 
 	var cmd *exec.Cmd
 	if ctx.AllowBuildShell && buildShell != nil {

--- a/treefmt.nix
+++ b/treefmt.nix
@@ -7,6 +7,7 @@
     shellcheck.enable = true; # bash/shell
     taplo.enable = true; # toml
     yamlfmt.enable = true; # yaml
+    gofmt.enable = true;
   };
   settings = {
     formatter = {

--- a/utils/context.go
+++ b/utils/context.go
@@ -8,7 +8,7 @@ import (
 // Create a context with a timeout, but only if the timeout is longer than 0
 func ContextWithConditionalTimeout(parent context.Context, timeout int) (context.Context, context.CancelFunc) {
 	var (
-		ctx context.Context
+		ctx    context.Context
 		cancel context.CancelFunc
 	)
 

--- a/utils/files.go
+++ b/utils/files.go
@@ -17,7 +17,7 @@ func GetAbsPathRelativeTo(path string, reference string) string {
 	}
 }
 
-func ValidateEnvironment(dependencies ...string)  {
+func ValidateEnvironment(dependencies ...string) {
 	missingDepencies := make([]string, 0)
 	for _, dependency := range dependencies {
 		_, err := exec.LookPath(dependency)
@@ -27,7 +27,7 @@ func ValidateEnvironment(dependencies ...string)  {
 	}
 
 	if len(missingDepencies) > 0 {
-		fmt.Fprint(os.Stderr, errors.New("Missing dependencies: '" + strings.Join(missingDepencies, ", ") + "' on $PATH"))
+		fmt.Fprint(os.Stderr, errors.New("Missing dependencies: '"+strings.Join(missingDepencies, ", ")+"' on $PATH"))
 		Exit(1)
 	}
 }

--- a/utils/finalizer.go
+++ b/utils/finalizer.go
@@ -16,9 +16,9 @@ type FinalizerFunc func()
 var finalizers []*finalizer
 
 /*
-	Finalizers run sequentially at morph shutdown - both at clean shutdown and on errors.
-	Finalizers should be quick, simple and they need to ignore errors and don't panic.
-	Each finalizer will only run once and will _never_ be re-invoked.
+Finalizers run sequentially at morph shutdown - both at clean shutdown and on errors.
+Finalizers should be quick, simple and they need to ignore errors and don't panic.
+Each finalizer will only run once and will _never_ be re-invoked.
 */
 func (f *finalizer) Run() {
 	if !f.executed {


### PR DESCRIPTION
- **feat(fmt): add gofmt to treefmt.nix**
- **build(flake): add `meta.mainProgram` so we can use `nix-command` features with morph**
- **style(go): treewide gofmt**
- **build(git): add treewide gofmt to `.git-blame-ignore-revs`**
