### PR TITLE
feat: add `preChecks`

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,16 @@ Health checks will be repeated until success, and the interval can be configured
 
 It is currently possible to have expressions like `"test \"$(systemctl list-units --failed --no-legend --no-pager |wc -l)\" -eq 0"` (count number of failed systemd units, fail if non-zero) as the first argument in a cmd-healthcheck. This works, but is discouraged, and might break at any time.
 
+
+### Pre-deploy checks (experimental)
+
+Morph supports running checks before changing the target host (note: files will still be pushed to the host).
+These checks work exactly like health checks, which means they will run forever until they have all succeeded.
+This is an _experimental feature that is very likely to change_ in the future. Comments and feedback welcome :).
+
+Pre-deploy checks can be defined using `deployment.preDeployChecks`.
+
+
 ### Advanced configuration
 
 **nix.conf-options:** The "network"-attrset supports a sub-attrset named "nixConfig". Options configured here will pass `--option <name> <value>` to all nix commands.

--- a/data/eval-machines.nix
+++ b/data/eval-machines.nix
@@ -112,7 +112,7 @@ rec {
         let v = scrubOptionValue v';
         in {
           inherit (v.config.deployment)
-            targetHost targetPort targetUser secrets healthChecks preChecks buildOnly
+            targetHost targetPort targetUser secrets preDeployChecks healthChecks buildOnly
             substituteOnDestination tags;
           name = n;
           nixosRelease = v.config.system.nixos.release or (removeSuffix

--- a/data/eval-machines.nix
+++ b/data/eval-machines.nix
@@ -112,7 +112,7 @@ rec {
         let v = scrubOptionValue v';
         in {
           inherit (v.config.deployment)
-            targetHost targetPort targetUser secrets healthChecks buildOnly
+            targetHost targetPort targetUser secrets healthChecks preChecks buildOnly
             substituteOnDestination tags;
           name = n;
           nixosRelease = v.config.system.nixos.release or (removeSuffix

--- a/data/options.nix
+++ b/data/options.nix
@@ -280,8 +280,8 @@ in
   # The file will end up linked in /run/current-system along with
   # all derived dependencies.
   config.system.extraDependencies =
-    let cmds = concatMap (h: h.cmd) config.deployment.healthChecks.cmd;
-    in [
-      (pkgs.writeText "healthcheck-commands.txt" (concatStringsSep "\n" cmds))
-    ];
+    let
+      cmds = concatMap (h: h.cmd) (config.deployment.healthChecks.cmd ++ config.deployment.preChecks.cmd);
+    in
+    [ (pkgs.writeText "healthcheck-commands.txt" (concatStringsSep "\n" cmds)) ];
 }

--- a/data/options.nix
+++ b/data/options.nix
@@ -92,6 +92,19 @@ let
     };
   });
 
+  preCheckType = submodule (_: {
+    options = {
+      cmd = mkOption {
+        type = listOf cmdHealthCheckType;
+        default = [ ];
+        description = ''
+          list of command prechecks,
+          runs healthcheck scripts pre-activation.
+        '';
+      };
+    };
+  });
+
   httpHealthCheckType = types.submodule (_: {
     options = {
       description = mkOption {
@@ -247,6 +260,13 @@ in
       default = { };
     };
 
+    preChecks = mkOption {
+      type = preCheckType;
+      description = ''
+        Pre-check configuration.
+      '';
+      default = { };
+    };
     tags = mkOption {
       type = listOf str;
       default = [ ];

--- a/data/options.nix
+++ b/data/options.nix
@@ -92,19 +92,6 @@ let
     };
   });
 
-  preCheckType = submodule (_: {
-    options = {
-      cmd = mkOption {
-        type = listOf cmdHealthCheckType;
-        default = [ ];
-        description = ''
-          list of command prechecks,
-          runs healthcheck scripts pre-activation.
-        '';
-      };
-    };
-  });
-
   httpHealthCheckType = types.submodule (_: {
     options = {
       description = mkOption {
@@ -260,8 +247,8 @@ in
       default = { };
     };
 
-    preChecks = mkOption {
-      type = preCheckType;
+    preDeployChecks = mkOption {
+      type = healthCheckType;
       description = ''
         Pre-check configuration.
       '';
@@ -281,7 +268,7 @@ in
   # all derived dependencies.
   config.system.extraDependencies =
     let
-      cmds = concatMap (h: h.cmd) (config.deployment.healthChecks.cmd ++ config.deployment.preChecks.cmd);
+      cmds = concatMap (h: h.cmd) (config.deployment.preDeployChecks.cmd ++ config.deployment.healthChecks.cmd);
     in
     [ (pkgs.writeText "healthcheck-commands.txt" (concatStringsSep "\n" cmds)) ];
 }

--- a/examples/healthchecks.nix
+++ b/examples/healthchecks.nix
@@ -47,6 +47,11 @@ in {
           }
         ];
       };
+
+      preDeployChecks = {
+        # Works exactly like health checks
+        # Have you read the warning about this feature in the README?
+      };
     };
   };
 }

--- a/healthchecks/healthchecks.go
+++ b/healthchecks/healthchecks.go
@@ -56,7 +56,7 @@ func PerformChecks(sshContext *ssh.SSHContext, checkName string, host Host, heal
 }
 
 func PerformPreDeployChecks(sshContext *ssh.SSHContext, host Host, timeout int) (err error) {
-	return PerformChecks(sshContext, "pre-deploy checks", host, host.GetPreActivationChecks(), timeout)
+	return PerformChecks(sshContext, "pre-deploy checks", host, host.GetPreDeployChecks(), timeout)
 }
 
 func PerformHealthChecks(sshContext *ssh.SSHContext, host Host, timeout int) (err error) {

--- a/healthchecks/types.go
+++ b/healthchecks/types.go
@@ -18,7 +18,7 @@ type Host interface {
 	GetTargetPort() int
 	GetTargetUser() string
 	GetHealthChecks() HealthChecks
-	GetPreActivationChecks() HealthChecks
+	GetPreDeployChecks() HealthChecks
 }
 
 type HealthChecks struct {

--- a/morph.go
+++ b/morph.go
@@ -47,7 +47,7 @@ var (
 	deployUploadSecrets bool
 	deployReboot        bool
 	skipHealthChecks    bool
-	skipPrechecks       bool
+	skipPreDeployChecks bool
 	showTrace           bool
 	healthCheck         = healthCheckCmd(app.Command("check-health", "Run health checks"))
 	uploadSecrets       = uploadSecretsCmd(app.Command("upload-secrets", "Upload secrets"))
@@ -136,11 +136,11 @@ func skipHealthChecksFlag(cmd *kingpin.CmdClause) {
 		BoolVar(&skipHealthChecks)
 }
 
-func skipPrechecksFlag(cmd *kingpin.CmdClause) {
+func skipPreDeployChecksFlag(cmd *kingpin.CmdClause) {
 	cmd.
-		Flag("skip-pre-activation-checks", "Whether to skip all pre checks").
+		Flag("skip-pre-deploy-checks", "Whether to skip all pre-deploy checks").
 		Default("False").
-		BoolVar(&skipPrechecks)
+		BoolVar(&skipPreDeployChecks)
 }
 
 func showTraceFlag(cmd *kingpin.CmdClause) {
@@ -204,7 +204,7 @@ func deployCmd(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 	askForSudoPasswdFlag(cmd)
 	getSudoPasswdCommand(cmd)
 	skipHealthChecksFlag(cmd)
-	skipPrechecksFlag(cmd)
+	skipPreDeployChecksFlag(cmd)
 	cmd.
 		Flag("upload-secrets", "Upload secrets as part of the host deployment").
 		Default("False").
@@ -417,11 +417,11 @@ func execDeploy(hosts []nix.Host) (string, error) {
 			fmt.Fprintln(os.Stderr)
 		}
 
-		if !skipPrechecks {
-			err := healthchecks.PerformPreChecks(sshContext, &host, timeout)
+		if !skipPreDeployChecks {
+			err := healthchecks.PerformPreDeployChecks(sshContext, &host, timeout)
 			if err != nil {
 				fmt.Fprintln(os.Stderr)
-				fmt.Fprintln(os.Stderr, "Not deploying to additional hosts, since a host pre-activation check failed.")
+				fmt.Fprintln(os.Stderr, "Not deploying to additional hosts, since a host pre-deploy check failed.")
 				utils.Exit(1)
 			}
 		}
@@ -452,7 +452,7 @@ func execDeploy(hosts []nix.Host) (string, error) {
 		}
 
 		if !skipHealthChecks {
-			err := healthchecks.Perform(sshContext, &host, timeout)
+			err := healthchecks.PerformHealthChecks(sshContext, &host, timeout)
 			if err != nil {
 				fmt.Fprintln(os.Stderr)
 				fmt.Fprintln(os.Stderr, "Not deploying to additional hosts, since a host health check failed.")
@@ -486,7 +486,7 @@ func execHealthCheck(hosts []nix.Host) error {
 			fmt.Fprintf(os.Stderr, "Healthchecks are disabled for build-only host: %s\n", host.Name)
 			continue
 		}
-		err = healthchecks.Perform(sshContext, &host, timeout)
+		err = healthchecks.PerformHealthChecks(sshContext, &host, timeout)
 	}
 
 	if err != nil {
@@ -510,7 +510,7 @@ func execUploadSecrets(sshContext *ssh.SSHContext, hosts []nix.Host, phase *stri
 		}
 
 		if !skipHealthChecks {
-			err = healthchecks.Perform(sshContext, &host, timeout)
+			err = healthchecks.PerformHealthChecks(sshContext, &host, timeout)
 			if err != nil {
 				fmt.Fprintln(os.Stderr)
 				fmt.Fprintln(os.Stderr, "Not uploading to additional hosts, since a host health check failed.")

--- a/nix/nix.go
+++ b/nix/nix.go
@@ -21,7 +21,7 @@ import (
 )
 
 type Host struct {
-	PreChecks               healthchecks.PreConditions
+	PreDeployChecks         healthchecks.HealthChecks
 	HealthChecks            healthchecks.HealthChecks
 	Name                    string
 	NixosRelease            string
@@ -155,8 +155,8 @@ func (host *Host) GetHealthChecks() healthchecks.HealthChecks {
 	return host.HealthChecks
 }
 
-func (host *Host) GetPreActivationChecks() healthchecks.PreConditions {
-	return host.PreChecks
+func (host *Host) GetPreActivationChecks() healthchecks.HealthChecks {
+	return host.PreDeployChecks
 }
 
 func (host *Host) GetTags() []string {

--- a/nix/nix.go
+++ b/nix/nix.go
@@ -21,6 +21,7 @@ import (
 )
 
 type Host struct {
+	PreChecks               healthchecks.PreConditions
 	HealthChecks            healthchecks.HealthChecks
 	Name                    string
 	NixosRelease            string
@@ -152,6 +153,10 @@ func (host *Host) GetTargetUser() string {
 
 func (host *Host) GetHealthChecks() healthchecks.HealthChecks {
 	return host.HealthChecks
+}
+
+func (host *Host) GetPreActivationChecks() healthchecks.PreConditions {
+	return host.PreChecks
 }
 
 func (host *Host) GetTags() []string {

--- a/nix/nix.go
+++ b/nix/nix.go
@@ -155,7 +155,7 @@ func (host *Host) GetHealthChecks() healthchecks.HealthChecks {
 	return host.HealthChecks
 }
 
-func (host *Host) GetPreActivationChecks() healthchecks.HealthChecks {
+func (host *Host) GetPreDeployChecks() healthchecks.HealthChecks {
 	return host.PreDeployChecks
 }
 


### PR DESCRIPTION
The idea is to have healthchecks in the pre-activation stage aswell, this is useful if you wanna make sure there are no active connections to the node you are about to switch. 

the api/logic is exactly like current healthchecks, except no `deployment.healthChecks.http` style checks.

example: 
```
  deployment.preChecks.cmd =
    [
      {
        cmd = [
          "false"
        ];
        description = "Node is quarantined, do not touch.";
      }
    ];
```
