### PR TITLE
Repair minor error in `examples/simple.nix`

### DIFF
--- a/examples/simple.nix
+++ b/examples/simple.nix
@@ -4,7 +4,7 @@ in
 {
   network = {
     inherit pkgs;
-    specialArgs = {
+    extraSpecialArgs = {
       systemdBoot = true;
     };
     description = "simple hosts";


### PR DESCRIPTION
I began learning `morph` by running `morph build examples/simple.nix`, and quickly came across an error - the `systemdBoot` variable had been missing. I made a lucky guess based on other Nix conventions, and had been pleased to see this is only a minor typo.

I hope this helps others learn and run `morph` hassle-free, because this seems to be the most reliable choice after months of minor annoyances managing `colmena`.