### PR TITLE
Extract deploy thingies from morph.go and update naming of "context"'s

### DIFF
--- a/cliparser/cliparser.go
+++ b/cliparser/cliparser.go
@@ -1,0 +1,229 @@
+package cliparser
+
+import (
+	"strings"
+
+	"github.com/DBCDK/kingpin"
+	"github.com/DBCDK/morph/common"
+)
+
+type KingpinCmdClauses struct {
+	Build         *kingpin.CmdClause
+	Deploy        *kingpin.CmdClause
+	Eval          *kingpin.CmdClause
+	Execute       *kingpin.CmdClause
+	HealthCheck   *kingpin.CmdClause
+	Push          *kingpin.CmdClause
+	SecretsUpload *kingpin.CmdClause
+	SecretsList   *kingpin.CmdClause
+}
+
+func New(version string, assetRoot string) (*kingpin.Application, *KingpinCmdClauses, *common.MorphOptions) {
+	app := kingpin.New("morph", "NixOS host manager").Version(version)
+
+	options := &common.MorphOptions{
+		Version:   version,
+		AssetRoot: assetRoot,
+
+		DryRun:          app.Flag("dry-run", "Don't do anything, just eval and print changes").Default("False").Bool(),
+		JsonOut:         app.Flag("i-know-kung-fu", "Output as JSON").Default("False").Bool(),
+		ConstraintsFlag: app.Flag("constraint", "Add constraints to manipulate order of execution").Default("").Strings(),
+		KeepGCRoot:      app.Flag("keep-result", "Keep latest build in .gcroots to prevent it from being garbage collected").Default("False").Bool(),
+		AllowBuildShell: app.Flag("allow-build-shell", "Allow using `network.buildShell` to build in a nix-shell which can execute arbitrary commands on the local system").Default("False").Bool(),
+	}
+
+	cmdClauses := &KingpinCmdClauses{
+		Build:         buildCmd(app.Command("build", "Evaluate and build deployment configuration to the local Nix store"), options),
+		Deploy:        deployCmd(app.Command("deploy", "Build, push and activate new configuration on machines according to switch-action"), options),
+		Eval:          evalCmd(app.Command("eval", "Inspect value of an attribute without building"), options),
+		Execute:       executeCmd(app.Command("exec", "Execute arbitrary commands on machines"), options),
+		HealthCheck:   healthCheckCmd(app.Command("check-health", "Run health checks"), options),
+		Push:          pushCmd(app.Command("push", "Build and transfer items from the local Nix store to target machines"), options),
+		SecretsList:   listSecretsCmd(app.Command("list-secrets", "List secrets"), options),
+		SecretsUpload: uploadSecretsCmd(app.Command("upload-secrets", "Upload secrets"), options),
+	}
+
+	return app, cmdClauses, options
+}
+
+func deploymentArg(cmd *kingpin.CmdClause, cfg *common.MorphOptions) {
+	cmd.Arg("deployment", "File containing the nix deployment expression").
+		HintFiles("nix").
+		Required().
+		ExistingFileVar(&cfg.Deployment)
+}
+
+func attributeArg(cmd *kingpin.CmdClause, cfg *common.MorphOptions) {
+	cmd.Arg("attribute", "Name of attribute to inspect").
+		Required().
+		StringVar(&cfg.AttrKey)
+}
+
+func timeoutFlag(cmd *kingpin.CmdClause, cfg *common.MorphOptions) {
+	cmd.Flag("timeout", "Seconds to wait for commands/healthchecks on a host to complete").
+		Default("0").
+		IntVar(&cfg.Timeout)
+}
+
+func askForSudoPasswdFlag(cmd *kingpin.CmdClause, cfg *common.MorphOptions) {
+	cmd.
+		Flag("passwd", "Whether to ask interactively for remote sudo password when needed").
+		Default("False").
+		BoolVar(&cfg.AskForSudoPasswd)
+}
+
+func getSudoPasswdCommand(cmd *kingpin.CmdClause, cfg *common.MorphOptions) {
+	cmd.
+		Flag("passcmd", "Specify command to run for sudo password").
+		Default("").
+		StringVar(&cfg.PassCmd)
+}
+
+func selectorFlags(cmd *kingpin.CmdClause, cfg *common.MorphOptions) {
+	cmd.Flag("on", "Glob for selecting servers in the deployment").
+		Default("*").
+		StringVar(&cfg.SelectGlob)
+	cmd.Flag("tagged", "Select hosts with these tags").
+		Default("").
+		StringVar(&cfg.SelectTags)
+	cmd.Flag("every", "Select every n hosts").
+		Default("1").
+		IntVar(&cfg.SelectEvery)
+	cmd.Flag("skip", "Skip first n hosts").
+		Default("0").
+		IntVar(&cfg.SelectSkip)
+	cmd.Flag("limit", "Select at most n hosts").
+		IntVar(&cfg.SelectLimit)
+	cmd.Flag("order-by-tags", "Order hosts by tags (comma separated list)").
+		Default("").
+		StringVar(&cfg.OrderingTags)
+}
+
+func nixBuildTargetFlag(cmd *kingpin.CmdClause, cfg *common.MorphOptions) {
+	cmd.Flag("target", "A Nix lambda defining the build target to use instead of the default").
+		StringVar(&cfg.NixBuildTarget)
+}
+
+func nixBuildTargetFileFlag(cmd *kingpin.CmdClause, cfg *common.MorphOptions) {
+	cmd.Flag("target-file", "File containing a Nix attribute set, defining build targets to use instead of the default").
+		HintFiles("nix").
+		ExistingFileVar(&cfg.NixBuildTargetFile)
+}
+
+func skipHealthChecksFlag(cmd *kingpin.CmdClause, cfg *common.MorphOptions) {
+	cmd.
+		Flag("skip-health-checks", "Whether to skip all health checks").
+		Default("False").
+		BoolVar(&cfg.SkipHealthChecks)
+}
+
+func skipPreDeployChecksFlag(cmd *kingpin.CmdClause, cfg *common.MorphOptions) {
+	cmd.
+		Flag("skip-pre-deploy-checks", "Whether to skip all pre-deploy checks").
+		Default("False").
+		BoolVar(&cfg.SkipPreDeployChecks)
+}
+
+func showTraceFlag(cmd *kingpin.CmdClause, cfg *common.MorphOptions) {
+	cmd.
+		Flag("show-trace", "Whether to pass --show-trace to all nix commands").
+		Default("False").
+		BoolVar(&cfg.ShowTrace)
+}
+
+func asJsonFlag(cmd *kingpin.CmdClause, cfg *common.MorphOptions) {
+	cmd.
+		Flag("json", "Whether to format the output as JSON instead of plaintext").
+		Default("False").
+		BoolVar(&cfg.AsJson)
+}
+
+func evalCmd(cmd *kingpin.CmdClause, cfg *common.MorphOptions) *kingpin.CmdClause {
+	deploymentArg(cmd, cfg)
+	attributeArg(cmd, cfg)
+	return cmd
+}
+
+func buildCmd(cmd *kingpin.CmdClause, cfg *common.MorphOptions) *kingpin.CmdClause {
+	selectorFlags(cmd, cfg)
+	showTraceFlag(cmd, cfg)
+	nixBuildTargetFlag(cmd, cfg)
+	nixBuildTargetFileFlag(cmd, cfg)
+	deploymentArg(cmd, cfg)
+	return cmd
+}
+
+func pushCmd(cmd *kingpin.CmdClause, cfg *common.MorphOptions) *kingpin.CmdClause {
+	selectorFlags(cmd, cfg)
+	showTraceFlag(cmd, cfg)
+	deploymentArg(cmd, cfg)
+	return cmd
+}
+
+func executeCmd(cmd *kingpin.CmdClause, cfg *common.MorphOptions) *kingpin.CmdClause {
+	selectorFlags(cmd, cfg)
+	showTraceFlag(cmd, cfg)
+	askForSudoPasswdFlag(cmd, cfg)
+	getSudoPasswdCommand(cmd, cfg)
+	timeoutFlag(cmd, cfg)
+	deploymentArg(cmd, cfg)
+	cmd.
+		Arg("command", "Command to execute").
+		Required().
+		StringsVar(&cfg.ExecuteCommand)
+	cmd.NoInterspersed = true
+	return cmd
+}
+
+func deployCmd(cmd *kingpin.CmdClause, cfg *common.MorphOptions) *kingpin.CmdClause {
+	switchActions := []string{"dry-activate", "test", "switch", "boot"}
+
+	selectorFlags(cmd, cfg)
+	showTraceFlag(cmd, cfg)
+	deploymentArg(cmd, cfg)
+	timeoutFlag(cmd, cfg)
+	askForSudoPasswdFlag(cmd, cfg)
+	getSudoPasswdCommand(cmd, cfg)
+	skipHealthChecksFlag(cmd, cfg)
+	skipPreDeployChecksFlag(cmd, cfg)
+	cmd.
+		Flag("upload-secrets", "Upload secrets as part of the host deployment").
+		Default("False").
+		BoolVar(&cfg.DeployUploadSecrets)
+	cmd.
+		Flag("reboot", "Reboots the host after system activation, but before healthchecks has executed.").
+		Default("False").
+		BoolVar(&cfg.DeployReboot)
+	cmd.
+		Arg("switch-action", "Either of "+strings.Join(switchActions, "|")).
+		Required().
+		HintOptions(switchActions...).
+		EnumVar(&cfg.DeploySwitchAction, switchActions...)
+	return cmd
+}
+
+func healthCheckCmd(cmd *kingpin.CmdClause, cfg *common.MorphOptions) *kingpin.CmdClause {
+	selectorFlags(cmd, cfg)
+	showTraceFlag(cmd, cfg)
+	deploymentArg(cmd, cfg)
+	timeoutFlag(cmd, cfg)
+	return cmd
+}
+
+func uploadSecretsCmd(cmd *kingpin.CmdClause, cfg *common.MorphOptions) *kingpin.CmdClause {
+	selectorFlags(cmd, cfg)
+	showTraceFlag(cmd, cfg)
+	askForSudoPasswdFlag(cmd, cfg)
+	getSudoPasswdCommand(cmd, cfg)
+	skipHealthChecksFlag(cmd, cfg)
+	deploymentArg(cmd, cfg)
+	return cmd
+}
+
+func listSecretsCmd(cmd *kingpin.CmdClause, cfg *common.MorphOptions) *kingpin.CmdClause {
+	selectorFlags(cmd, cfg)
+	showTraceFlag(cmd, cfg)
+	deploymentArg(cmd, cfg)
+	asJsonFlag(cmd, cfg)
+	return cmd
+}

--- a/common/common.go
+++ b/common/common.go
@@ -1,0 +1,35 @@
+package common
+
+type MorphOptions struct {
+	Version   string
+	AssetRoot string
+
+	DryRun          *bool
+	JsonOut         *bool
+	ConstraintsFlag *[]string
+	KeepGCRoot      *bool
+	AllowBuildShell *bool
+
+	AsJson              bool
+	AskForSudoPasswd    bool
+	AttrKey             string
+	Deployment          string
+	DeploymentsDir      string
+	DeployReboot        bool
+	DeploySwitchAction  string
+	DeployUploadSecrets bool
+	ExecuteCommand      []string
+	NixBuildTarget      string
+	NixBuildTargetFile  string
+	OrderingTags        string
+	PassCmd             string
+	SelectEvery         int
+	SelectGlob          string
+	SelectLimit         int
+	SelectSkip          int
+	SelectTags          string
+	ShowTrace           bool
+	SkipHealthChecks    bool
+	SkipPreDeployChecks bool
+	Timeout             int
+}

--- a/cruft/deploy.go
+++ b/cruft/deploy.go
@@ -1,0 +1,313 @@
+package cruft
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/DBCDK/morph/common"
+	"github.com/DBCDK/morph/filter"
+	"github.com/DBCDK/morph/healthchecks"
+	"github.com/DBCDK/morph/nix"
+	"github.com/DBCDK/morph/ssh"
+	"github.com/DBCDK/morph/utils"
+)
+
+func ExecBuild(opts *common.MorphOptions, hosts []nix.Host) (string, error) {
+	resultPath, err := buildHosts(opts, hosts)
+	if err != nil {
+		return "", err
+	}
+	return resultPath, nil
+}
+
+func ExecDeploy(opts *common.MorphOptions, hosts []nix.Host) (string, error) {
+	sshContext := ssh.CreateSSHContext(opts)
+
+	doPush := false
+	doUploadSecrets := false
+	doActivate := false
+
+	if !*opts.DryRun {
+		switch opts.DeploySwitchAction {
+		case "dry-activate":
+			doPush = true
+			doActivate = true
+		case "test":
+			fallthrough
+		case "switch":
+			fallthrough
+		case "boot":
+			doPush = true
+			doUploadSecrets = opts.DeployUploadSecrets
+			doActivate = true
+		}
+	}
+
+	resultPath, err := buildHosts(opts, hosts)
+	if err != nil {
+		return "", err
+	}
+
+	fmt.Fprintln(os.Stderr)
+
+	for _, host := range hosts {
+		if host.BuildOnly {
+			fmt.Fprintf(os.Stderr, "Deployment steps are disabled for build-only host: %s\n", host.Name)
+			continue
+		}
+
+		singleHostInList := []nix.Host{host}
+
+		if doPush {
+			err = pushPaths(sshContext, singleHostInList, resultPath)
+			if err != nil {
+				return "", err
+			}
+		}
+		fmt.Fprintln(os.Stderr)
+
+		if doUploadSecrets {
+			phase := "pre-activation"
+			err = ExecUploadSecrets(opts, singleHostInList, &phase)
+			if err != nil {
+				return "", err
+			}
+
+			fmt.Fprintln(os.Stderr)
+		}
+
+		if !opts.SkipPreDeployChecks {
+			err := healthchecks.PerformPreDeployChecks(sshContext, &host, opts.Timeout)
+			if err != nil {
+				fmt.Fprintln(os.Stderr)
+				fmt.Fprintln(os.Stderr, "Not deploying to additional hosts, since a host pre-deploy check failed.")
+				utils.Exit(1)
+			}
+		}
+
+		if doActivate {
+			err = activateConfiguration(opts, sshContext, singleHostInList, resultPath)
+			if err != nil {
+				return "", err
+			}
+		}
+
+		if opts.DeployReboot {
+			err = host.Reboot(sshContext)
+			if err != nil {
+				fmt.Fprintln(os.Stderr, "Reboot failed")
+				return "", err
+			}
+		}
+
+		if doUploadSecrets {
+			phase := "post-activation"
+			err = ExecUploadSecrets(opts, singleHostInList, &phase)
+			if err != nil {
+				return "", err
+			}
+
+			fmt.Fprintln(os.Stderr)
+		}
+
+		if !opts.SkipHealthChecks {
+			err := healthchecks.PerformHealthChecks(sshContext, &host, opts.Timeout)
+			if err != nil {
+				fmt.Fprintln(os.Stderr)
+				fmt.Fprintln(os.Stderr, "Not deploying to additional hosts, since a host health check failed.")
+				utils.Exit(1)
+			}
+		}
+
+		fmt.Fprintln(os.Stderr, "Done:", host.Name)
+	}
+
+	return resultPath, nil
+}
+
+func ExecEval(opts *common.MorphOptions) (string, error) {
+	deploymentFile, err := os.Open(opts.Deployment)
+	deploymentPath, err := filepath.Abs(deploymentFile.Name())
+	if err != nil {
+		return "", err
+	}
+
+	path, err := nix.GetNixContext(opts).EvalHosts(deploymentPath, opts.AttrKey)
+
+	return path, err
+}
+
+func ExecExecute(opts *common.MorphOptions, hosts []nix.Host) error {
+	sshContext := ssh.CreateSSHContext(opts)
+
+	for _, host := range hosts {
+		if host.BuildOnly {
+			fmt.Fprintf(os.Stderr, "Exec is disabled for build-only host: %s\n", host.Name)
+			continue
+		}
+		fmt.Fprintln(os.Stderr, "** "+host.Name)
+		sshContext.CmdInteractive(&host, opts.Timeout, opts.ExecuteCommand...)
+		fmt.Fprintln(os.Stderr)
+	}
+
+	return nil
+}
+
+func ExecHealthCheck(opts *common.MorphOptions, hosts []nix.Host) error {
+	sshContext := ssh.CreateSSHContext(opts)
+
+	var err error
+	for _, host := range hosts {
+		if host.BuildOnly {
+			fmt.Fprintf(os.Stderr, "Healthchecks are disabled for build-only host: %s\n", host.Name)
+			continue
+		}
+		err = healthchecks.PerformHealthChecks(sshContext, &host, opts.Timeout)
+	}
+
+	if err != nil {
+		err = errors.New("One or more errors occurred during host healthchecks")
+	}
+
+	return err
+}
+
+func ExecPush(opts *common.MorphOptions, hosts []nix.Host) (string, error) {
+	resultPath, err := ExecBuild(opts, hosts)
+	if err != nil {
+		return "", err
+	}
+
+	fmt.Fprintln(os.Stderr)
+	return resultPath, pushPaths(ssh.CreateSSHContext(opts), hosts, resultPath)
+}
+
+func GetHosts(opts *common.MorphOptions) (hosts []nix.Host, err error) {
+
+	deploymentFile, err := os.Open(opts.Deployment)
+	if err != nil {
+		return hosts, err
+	}
+
+	deploymentAbsPath, err := filepath.Abs(deploymentFile.Name())
+	if err != nil {
+		return hosts, err
+	}
+
+	ctx := nix.GetNixContext(opts)
+	deployment, err := ctx.GetMachines(deploymentAbsPath)
+	if err != nil {
+		return hosts, err
+	}
+
+	matchingHosts, err := filter.MatchHosts(deployment.Hosts, opts.SelectGlob)
+	if err != nil {
+		return hosts, err
+	}
+
+	var selectedTags []string
+	if opts.SelectTags != "" {
+		selectedTags = strings.Split(opts.SelectTags, ",")
+	}
+
+	matchingHosts2 := filter.FilterHostsTags(matchingHosts, selectedTags)
+
+	ordering := deployment.Meta.Ordering
+	if opts.OrderingTags != "" {
+		ordering = nix.HostOrdering{Tags: strings.Split(opts.OrderingTags, ",")}
+	}
+
+	sortedHosts := filter.SortHosts(matchingHosts2, ordering)
+
+	filteredHosts := filter.FilterHosts(sortedHosts, opts.SelectSkip, opts.SelectEvery, opts.SelectLimit)
+
+	fmt.Fprintf(os.Stderr, "Selected %v/%v hosts (name filter:-%v, limits:-%v):\n", len(filteredHosts), len(deployment.Hosts), len(deployment.Hosts)-len(matchingHosts), len(matchingHosts)-len(filteredHosts))
+	for index, host := range filteredHosts {
+		fmt.Fprintf(os.Stderr, "\t%3d: %s (secrets: %d, health checks: %d, tags: %s)\n", index, host.Name, len(host.Secrets), len(host.HealthChecks.Cmd)+len(host.HealthChecks.Http), strings.Join(host.GetTags(), ","))
+	}
+	fmt.Fprintln(os.Stderr)
+
+	return filteredHosts, nil
+}
+
+func activateConfiguration(opts *common.MorphOptions, ctx ssh.Context, filteredHosts []nix.Host, resultPath string) error {
+	fmt.Fprintln(os.Stderr, "Executing '"+opts.DeploySwitchAction+"' on matched hosts:")
+	fmt.Fprintln(os.Stderr)
+	for _, host := range filteredHosts {
+
+		fmt.Fprintln(os.Stderr, "** "+host.Name)
+
+		configuration, err := nix.GetNixSystemPath(host, resultPath)
+		if err != nil {
+			return err
+		}
+
+		err = ctx.ActivateConfiguration(&host, configuration, opts.DeploySwitchAction)
+		if err != nil {
+			return err
+		}
+
+		fmt.Fprintln(os.Stderr)
+	}
+
+	return nil
+}
+
+func buildHosts(opts *common.MorphOptions, hosts []nix.Host) (resultPath string, err error) {
+	if len(hosts) == 0 {
+		err = errors.New("No hosts selected")
+		return
+	}
+
+	deploymentPath, err := filepath.Abs(opts.Deployment)
+	if err != nil {
+		return
+	}
+
+	nixBuildTargets := ""
+	if opts.NixBuildTargetFile != "" {
+		if path, err := filepath.Abs(opts.NixBuildTargetFile); err == nil {
+			nixBuildTargets = fmt.Sprintf("import \"%s\"", path)
+		}
+	} else if opts.NixBuildTarget != "" {
+		nixBuildTargets = fmt.Sprintf("{ \"out\" = %s; }", opts.NixBuildTarget)
+	}
+
+	ctx := nix.GetNixContext(opts)
+	resultPath, err = ctx.BuildMachines(deploymentPath, hosts, nixBuildTargets)
+
+	if err != nil {
+		return
+	}
+
+	fmt.Fprintln(os.Stderr, "nix result path: ")
+	fmt.Println(resultPath)
+	return
+}
+
+func pushPaths(sshContext *ssh.SSHContext, filteredHosts []nix.Host, resultPath string) error {
+	for _, host := range filteredHosts {
+		if host.BuildOnly {
+			fmt.Fprintf(os.Stderr, "Push is disabled for build-only host: %s\n", host.Name)
+			continue
+		}
+
+		paths, err := nix.GetPathsToPush(host, resultPath)
+		if err != nil {
+			return err
+		}
+		fmt.Fprintf(os.Stderr, "Pushing paths to %v (%v@%v):\n", host.Name, host.TargetUser, host.TargetHost)
+		for _, path := range paths {
+			fmt.Fprintf(os.Stderr, "\t* %s\n", path)
+		}
+		err = nix.Push(sshContext, host, paths...)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/cruft/secrets.go
+++ b/cruft/secrets.go
@@ -1,0 +1,134 @@
+package cruft
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/DBCDK/morph/common"
+	"github.com/DBCDK/morph/healthchecks"
+	"github.com/DBCDK/morph/nix"
+	"github.com/DBCDK/morph/secrets"
+	"github.com/DBCDK/morph/ssh"
+	"github.com/DBCDK/morph/utils"
+)
+
+func ExecListSecrets(hosts []nix.Host) {
+	for _, host := range hosts {
+		singleHostInList := []nix.Host{host}
+		for _, host := range singleHostInList {
+			fmt.Fprintf(os.Stdout, "Secrets for host %s:\n", host.Name)
+			for name, secret := range host.Secrets {
+				fmt.Fprintf(os.Stdout, "%s:\n- %v\n", name, &secret)
+			}
+			fmt.Fprintf(os.Stdout, "\n")
+		}
+	}
+}
+
+func ExecListSecretsAsJson(opts *common.MorphOptions, hosts []nix.Host) error {
+	deploymentDir, err := filepath.Abs(filepath.Dir(opts.Deployment))
+	if err != nil {
+		return err
+	}
+	secretsByHost := make(map[string](map[string]secrets.Secret))
+
+	for _, host := range hosts {
+		singleHostInList := []nix.Host{host}
+		for _, host := range singleHostInList {
+			canonicalSecrets := make(map[string]secrets.Secret)
+			for name, secret := range host.Secrets {
+				sourcePath := utils.GetAbsPathRelativeTo(secret.Source, deploymentDir)
+				secret.Source = sourcePath
+				canonicalSecrets[name] = secret
+			}
+			secretsByHost[host.Name] = canonicalSecrets
+		}
+	}
+
+	jsonSecrets, err := json.MarshalIndent(secretsByHost, "", "  ")
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(os.Stdout, "%s\n", jsonSecrets)
+
+	return nil
+}
+
+func ExecUploadSecrets(opts *common.MorphOptions, hosts []nix.Host, phase *string) error {
+	sshContext := ssh.CreateSSHContext(opts)
+
+	for _, host := range hosts {
+		if host.BuildOnly {
+			fmt.Fprintf(os.Stderr, "Secret upload is disabled for build-only host: %s\n", host.Name)
+			continue
+		}
+		singleHostInList := []nix.Host{host}
+
+		err := secretsUpload(opts, sshContext, singleHostInList, phase)
+		if err != nil {
+			return err
+		}
+
+		if !opts.SkipHealthChecks {
+			err = healthchecks.PerformHealthChecks(sshContext, &host, opts.Timeout)
+			if err != nil {
+				fmt.Fprintln(os.Stderr)
+				fmt.Fprintln(os.Stderr, "Not uploading to additional hosts, since a host health check failed.")
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func secretsUpload(opts *common.MorphOptions, ctx ssh.Context, filteredHosts []nix.Host, phase *string) error {
+	// upload secrets
+	// relative paths are resolved relative to the deployment file (!)
+	deploymentDir := filepath.Dir(opts.Deployment)
+	for _, host := range filteredHosts {
+		fmt.Fprintf(os.Stderr, "Uploading secrets to %s (%s):\n", host.Name, host.TargetHost)
+		postUploadActions := make(map[string][]string, 0)
+		for secretName, secret := range host.Secrets {
+			// if phase is nil, upload the secrets no matter what phase it wants
+			// if phase is non-nil, upload the secrets that match the specified phase
+			if phase != nil && secret.UploadAt != *phase {
+				continue
+			}
+
+			secretSize, err := secrets.GetSecretSize(secret, deploymentDir)
+			if err != nil {
+				return err
+			}
+
+			secretErr := secrets.UploadSecret(ctx, &host, secret, deploymentDir)
+			fmt.Fprintf(os.Stderr, "\t* %s (%d bytes).. ", secretName, secretSize)
+			if secretErr != nil {
+				if secretErr.Fatal {
+					fmt.Fprintln(os.Stderr, "Failed")
+					return secretErr
+				} else {
+					fmt.Fprintln(os.Stderr, "Partial")
+					fmt.Fprint(os.Stderr, secretErr.Error())
+				}
+			} else {
+				fmt.Fprintln(os.Stderr, "OK")
+			}
+			if len(secret.Action) > 0 {
+				// ensure each action is only run once
+				postUploadActions[strings.Join(secret.Action, " ")] = secret.Action
+			}
+		}
+		// Execute post-upload secret actions one-by-one after all secrets have been uploaded
+		for _, action := range postUploadActions {
+			fmt.Fprintf(os.Stderr, "\t- executing post-upload command: "+strings.Join(action, " ")+"\n")
+			// Errors from secret actions will be printed on screen, but we won't stop the flow if they fail
+			ctx.CmdInteractive(&host, opts.Timeout, action...)
+		}
+	}
+
+	return nil
+}

--- a/healthchecks/types.go
+++ b/healthchecks/types.go
@@ -5,11 +5,12 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
-	"github.com/DBCDK/morph/ssh"
-	"github.com/DBCDK/morph/utils"
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/DBCDK/morph/ssh"
+	"github.com/DBCDK/morph/utils"
 )
 
 type Host interface {

--- a/morph.go
+++ b/morph.go
@@ -36,7 +36,6 @@ var (
 	timeout             int
 	askForSudoPasswd    bool
 	passCmd             string
-	nixBuildArg         []string
 	nixBuildTarget      string
 	nixBuildTargetFile  string
 	build               = buildCmd(app.Command("build", "Evaluate and build deployment configuration to the local Nix store"))
@@ -113,11 +112,6 @@ func selectorFlags(cmd *kingpin.CmdClause) {
 		StringVar(&orderingTags)
 }
 
-func nixBuildArgFlag(cmd *kingpin.CmdClause) {
-	cmd.Flag("build-arg", "Extra argument to pass on to nix-build command. **DEPRECATED**").
-		StringsVar(&nixBuildArg)
-}
-
 func nixBuildTargetFlag(cmd *kingpin.CmdClause) {
 	cmd.Flag("target", "A Nix lambda defining the build target to use instead of the default").
 		StringVar(&nixBuildTarget)
@@ -166,7 +160,6 @@ func evalCmd(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 func buildCmd(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 	selectorFlags(cmd)
 	showTraceFlag(cmd)
-	nixBuildArgFlag(cmd)
 	nixBuildTargetFlag(cmd)
 	nixBuildTargetFileFlag(cmd)
 	deploymentArg(cmd)
@@ -198,7 +191,6 @@ func executeCmd(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 func deployCmd(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 	selectorFlags(cmd)
 	showTraceFlag(cmd)
-	nixBuildArgFlag(cmd)
 	deploymentArg(cmd)
 	timeoutFlag(cmd)
 	askForSudoPasswdFlag(cmd)
@@ -260,11 +252,6 @@ func setup() {
 func main() {
 
 	clause := kingpin.MustParse(app.Parse(os.Args[1:]))
-
-	//TODO: Remove deprecation warning when removing --build-arg flag
-	if len(nixBuildArg) > 0 {
-		fmt.Fprintln(os.Stderr, "Deprecation: The --build-arg flag will be removed in a future release.")
-	}
 
 	defer utils.RunFinalizers()
 	setup()
@@ -663,7 +650,7 @@ func buildHosts(hosts []nix.Host) (resultPath string, err error) {
 	}
 
 	ctx := getNixContext()
-	resultPath, err = ctx.BuildMachines(deploymentPath, hosts, nixBuildArg, nixBuildTargets)
+	resultPath, err = ctx.BuildMachines(deploymentPath, hosts, nixBuildTargets)
 
 	if err != nil {
 		return

--- a/morph.go
+++ b/morph.go
@@ -1,23 +1,13 @@
 package main
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/DBCDK/morph/cliparser"
-	"github.com/DBCDK/morph/common"
 	"os"
-	"path/filepath"
-	"strings"
 
 	"github.com/DBCDK/kingpin"
 	"github.com/DBCDK/morph/cliparser"
-	"github.com/DBCDK/morph/common"
-	"github.com/DBCDK/morph/filter"
-	"github.com/DBCDK/morph/healthchecks"
-	"github.com/DBCDK/morph/nix"
-	"github.com/DBCDK/morph/secrets"
-	"github.com/DBCDK/morph/ssh"
+	"github.com/DBCDK/morph/cruft"
 	"github.com/DBCDK/morph/utils"
 )
 
@@ -46,34 +36,34 @@ func main() {
 	// evaluate without building hosts
 	switch clause {
 	case cmdClauses.Eval.FullCommand():
-		_, err := execEval(opts)
+		_, err := cruft.ExecEval(opts)
 		handleError(err)
 		return
 	}
 
 	// setup hosts
-	hosts, err := getHosts(opts)
+	hosts, err := cruft.GetHosts(opts)
 	handleError(err)
 
 	switch clause {
 	case cmdClauses.Build.FullCommand():
-		_, err = execBuild(opts, hosts)
+		_, err = cruft.ExecBuild(opts, hosts)
 	case cmdClauses.Push.FullCommand():
-		_, err = execPush(opts, hosts)
+		_, err = cruft.ExecPush(opts, hosts)
 	case cmdClauses.Deploy.FullCommand():
-		_, err = execDeploy(opts, hosts)
+		_, err = cruft.ExecDeploy(opts, hosts)
 	case cmdClauses.HealthCheck.FullCommand():
-		err = execHealthCheck(opts, hosts)
+		err = cruft.ExecHealthCheck(opts, hosts)
 	case cmdClauses.SecretsUpload.FullCommand():
-		err = execUploadSecrets(opts, hosts, nil)
+		err = cruft.ExecUploadSecrets(opts, hosts, nil)
 	case cmdClauses.SecretsList.FullCommand():
 		if opts.AsJson {
-			err = execListSecretsAsJson(opts, hosts)
+			err = cruft.ExecListSecretsAsJson(opts, hosts)
 		} else {
-			execListSecrets(hosts)
+			cruft.ExecListSecrets(hosts)
 		}
 	case cmdClauses.Execute.FullCommand():
-		err = execExecute(opts, hosts)
+		err = cruft.ExecExecute(opts, hosts)
 	}
 
 	handleError(err)
@@ -85,462 +75,4 @@ func handleError(err error) {
 		fmt.Fprintln(os.Stderr, err)
 		utils.Exit(1)
 	}
-}
-
-func execExecute(opts *common.MorphOptions, hosts []nix.Host) error {
-	sshContext := createSSHContext(opts)
-
-	for _, host := range hosts {
-		if host.BuildOnly {
-			fmt.Fprintf(os.Stderr, "Exec is disabled for build-only host: %s\n", host.Name)
-			continue
-		}
-		fmt.Fprintln(os.Stderr, "** "+host.Name)
-		sshContext.CmdInteractive(&host, opts.Timeout, opts.ExecuteCommand...)
-		fmt.Fprintln(os.Stderr)
-	}
-
-	return nil
-}
-
-func execBuild(opts *common.MorphOptions, hosts []nix.Host) (string, error) {
-	resultPath, err := buildHosts(opts, hosts)
-	if err != nil {
-		return "", err
-	}
-	return resultPath, nil
-}
-
-func execEval(opts *common.MorphOptions) (string, error) {
-	ctx := getNixContext(opts)
-
-	deploymentFile, err := os.Open(opts.Deployment)
-	deploymentPath, err := filepath.Abs(deploymentFile.Name())
-	if err != nil {
-		return "", err
-	}
-
-	path, err := ctx.EvalHosts(deploymentPath, opts.AttrKey)
-
-	return path, err
-}
-
-func execPush(opts *common.MorphOptions, hosts []nix.Host) (string, error) {
-	resultPath, err := execBuild(opts, hosts)
-	if err != nil {
-		return "", err
-	}
-
-	fmt.Fprintln(os.Stderr)
-	return resultPath, pushPaths(createSSHContext(opts), hosts, resultPath)
-}
-
-func execDeploy(opts *common.MorphOptions, hosts []nix.Host) (string, error) {
-	doPush := false
-	doUploadSecrets := false
-	doActivate := false
-
-	if !*opts.DryRun {
-		switch opts.DeploySwitchAction {
-		case "dry-activate":
-			doPush = true
-			doActivate = true
-		case "test":
-			fallthrough
-		case "switch":
-			fallthrough
-		case "boot":
-			doPush = true
-			doUploadSecrets = opts.DeployUploadSecrets
-			doActivate = true
-		}
-	}
-
-	resultPath, err := buildHosts(opts, hosts)
-	if err != nil {
-		return "", err
-	}
-
-	fmt.Fprintln(os.Stderr)
-
-	sshContext := createSSHContext(opts)
-
-	for _, host := range hosts {
-		if host.BuildOnly {
-			fmt.Fprintf(os.Stderr, "Deployment steps are disabled for build-only host: %s\n", host.Name)
-			continue
-		}
-
-		singleHostInList := []nix.Host{host}
-
-		if doPush {
-			err = pushPaths(sshContext, singleHostInList, resultPath)
-			if err != nil {
-				return "", err
-			}
-		}
-		fmt.Fprintln(os.Stderr)
-
-		if doUploadSecrets {
-			phase := "pre-activation"
-			err = execUploadSecrets(opts, singleHostInList, &phase)
-			if err != nil {
-				return "", err
-			}
-
-			fmt.Fprintln(os.Stderr)
-		}
-
-		if !opts.SkipPreDeployChecks {
-			err := healthchecks.PerformPreDeployChecks(sshContext, &host, opts.Timeout)
-			if err != nil {
-				fmt.Fprintln(os.Stderr)
-				fmt.Fprintln(os.Stderr, "Not deploying to additional hosts, since a host pre-deploy check failed.")
-				utils.Exit(1)
-			}
-		}
-
-		if doActivate {
-			err = activateConfiguration(opts, sshContext, singleHostInList, resultPath)
-			if err != nil {
-				return "", err
-			}
-		}
-
-		if opts.DeployReboot {
-			err = host.Reboot(sshContext)
-			if err != nil {
-				fmt.Fprintln(os.Stderr, "Reboot failed")
-				return "", err
-			}
-		}
-
-		if doUploadSecrets {
-			phase := "post-activation"
-			err = execUploadSecrets(opts, singleHostInList, &phase)
-			if err != nil {
-				return "", err
-			}
-
-			fmt.Fprintln(os.Stderr)
-		}
-
-		if !opts.SkipHealthChecks {
-			err := healthchecks.PerformHealthChecks(sshContext, &host, opts.Timeout)
-			if err != nil {
-				fmt.Fprintln(os.Stderr)
-				fmt.Fprintln(os.Stderr, "Not deploying to additional hosts, since a host health check failed.")
-				utils.Exit(1)
-			}
-		}
-
-		fmt.Fprintln(os.Stderr, "Done:", host.Name)
-	}
-
-	return resultPath, nil
-}
-
-func createSSHContext(opts *common.MorphOptions) *ssh.SSHContext {
-	return &ssh.SSHContext{
-		AskForSudoPassword:     opts.AskForSudoPasswd,
-		GetSudoPasswordCommand: opts.PassCmd,
-		IdentityFile:           os.Getenv("SSH_IDENTITY_FILE"),
-		DefaultUsername:        os.Getenv("SSH_USER"),
-		SkipHostKeyCheck:       os.Getenv("SSH_SKIP_HOST_KEY_CHECK") != "",
-		ConfigFile:             os.Getenv("SSH_CONFIG_FILE"),
-	}
-}
-
-func execHealthCheck(opts *common.MorphOptions, hosts []nix.Host) error {
-	sshContext := createSSHContext(opts)
-
-	var err error
-	for _, host := range hosts {
-		if host.BuildOnly {
-			fmt.Fprintf(os.Stderr, "Healthchecks are disabled for build-only host: %s\n", host.Name)
-			continue
-		}
-		err = healthchecks.PerformHealthChecks(sshContext, &host, opts.Timeout)
-	}
-
-	if err != nil {
-		err = errors.New("One or more errors occurred during host healthchecks")
-	}
-
-	return err
-}
-
-func execUploadSecrets(opts *common.MorphOptions, hosts []nix.Host, phase *string) error {
-	sshContext := createSSHContext(opts)
-
-	for _, host := range hosts {
-		if host.BuildOnly {
-			fmt.Fprintf(os.Stderr, "Secret upload is disabled for build-only host: %s\n", host.Name)
-			continue
-		}
-		singleHostInList := []nix.Host{host}
-
-		err := secretsUpload(opts, sshContext, singleHostInList, phase)
-		if err != nil {
-			return err
-		}
-
-		if !opts.SkipHealthChecks {
-			err = healthchecks.PerformHealthChecks(sshContext, &host, opts.Timeout)
-			if err != nil {
-				fmt.Fprintln(os.Stderr)
-				fmt.Fprintln(os.Stderr, "Not uploading to additional hosts, since a host health check failed.")
-				return err
-			}
-		}
-	}
-
-	return nil
-}
-
-func execListSecrets(hosts []nix.Host) {
-	for _, host := range hosts {
-		singleHostInList := []nix.Host{host}
-		for _, host := range singleHostInList {
-			fmt.Fprintf(os.Stdout, "Secrets for host %s:\n", host.Name)
-			for name, secret := range host.Secrets {
-				fmt.Fprintf(os.Stdout, "%s:\n- %v\n", name, &secret)
-			}
-			fmt.Fprintf(os.Stdout, "\n")
-		}
-	}
-}
-
-func execListSecretsAsJson(opts *common.MorphOptions, hosts []nix.Host) error {
-	deploymentDir, err := filepath.Abs(filepath.Dir(opts.Deployment))
-	if err != nil {
-		return err
-	}
-	secretsByHost := make(map[string](map[string]secrets.Secret))
-
-	for _, host := range hosts {
-		singleHostInList := []nix.Host{host}
-		for _, host := range singleHostInList {
-			canonicalSecrets := make(map[string]secrets.Secret)
-			for name, secret := range host.Secrets {
-				sourcePath := utils.GetAbsPathRelativeTo(secret.Source, deploymentDir)
-				secret.Source = sourcePath
-				canonicalSecrets[name] = secret
-			}
-			secretsByHost[host.Name] = canonicalSecrets
-		}
-	}
-
-	jsonSecrets, err := json.MarshalIndent(secretsByHost, "", "  ")
-	if err != nil {
-		return err
-	}
-	fmt.Fprintf(os.Stdout, "%s\n", jsonSecrets)
-
-	return nil
-}
-
-func getHosts(opts *common.MorphOptions) (hosts []nix.Host, err error) {
-
-	deploymentFile, err := os.Open(opts.Deployment)
-	if err != nil {
-		return hosts, err
-	}
-
-	deploymentAbsPath, err := filepath.Abs(deploymentFile.Name())
-	if err != nil {
-		return hosts, err
-	}
-
-	ctx := getNixContext(opts)
-	deployment, err := ctx.GetMachines(deploymentAbsPath)
-	if err != nil {
-		return hosts, err
-	}
-
-	matchingHosts, err := filter.MatchHosts(deployment.Hosts, opts.SelectGlob)
-	if err != nil {
-		return hosts, err
-	}
-
-	var selectedTags []string
-	if opts.SelectTags != "" {
-		selectedTags = strings.Split(opts.SelectTags, ",")
-	}
-
-	matchingHosts2 := filter.FilterHostsTags(matchingHosts, selectedTags)
-
-	ordering := deployment.Meta.Ordering
-	if opts.OrderingTags != "" {
-		ordering = nix.HostOrdering{Tags: strings.Split(opts.OrderingTags, ",")}
-	}
-
-	sortedHosts := filter.SortHosts(matchingHosts2, ordering)
-
-	filteredHosts := filter.FilterHosts(sortedHosts, opts.SelectSkip, opts.SelectEvery, opts.SelectLimit)
-
-	fmt.Fprintf(os.Stderr, "Selected %v/%v hosts (name filter:-%v, limits:-%v):\n", len(filteredHosts), len(deployment.Hosts), len(deployment.Hosts)-len(matchingHosts), len(matchingHosts)-len(filteredHosts))
-	for index, host := range filteredHosts {
-		fmt.Fprintf(os.Stderr, "\t%3d: %s (secrets: %d, health checks: %d, tags: %s)\n", index, host.Name, len(host.Secrets), len(host.HealthChecks.Cmd)+len(host.HealthChecks.Http), strings.Join(host.GetTags(), ","))
-	}
-	fmt.Fprintln(os.Stderr)
-
-	return filteredHosts, nil
-}
-
-func getNixContext(opts *common.MorphOptions) *nix.NixContext {
-	evalCmd := os.Getenv("MORPH_NIX_EVAL_CMD")
-	buildCmd := os.Getenv("MORPH_NIX_BUILD_CMD")
-	shellCmd := os.Getenv("MORPH_NIX_SHELL_CMD")
-	evalMachines := os.Getenv("MORPH_NIX_EVAL_MACHINES")
-
-	if evalCmd == "" {
-		evalCmd = "nix-instantiate"
-	}
-	if buildCmd == "" {
-		buildCmd = "nix-build"
-	}
-	if shellCmd == "" {
-		shellCmd = "nix-shell"
-	}
-	if evalMachines == "" {
-		evalMachines = filepath.Join(opts.AssetRoot, "eval-machines.nix")
-	}
-
-	return &nix.NixContext{
-		EvalCmd:         evalCmd,
-		BuildCmd:        buildCmd,
-		ShellCmd:        shellCmd,
-		EvalMachines:    evalMachines,
-		ShowTrace:       opts.ShowTrace,
-		KeepGCRoot:      *opts.KeepGCRoot,
-		AllowBuildShell: *opts.AllowBuildShell,
-	}
-}
-
-func buildHosts(opts *common.MorphOptions, hosts []nix.Host) (resultPath string, err error) {
-	if len(hosts) == 0 {
-		err = errors.New("No hosts selected")
-		return
-	}
-
-	deploymentPath, err := filepath.Abs(opts.Deployment)
-	if err != nil {
-		return
-	}
-
-	nixBuildTargets := ""
-	if opts.NixBuildTargetFile != "" {
-		if path, err := filepath.Abs(opts.NixBuildTargetFile); err == nil {
-			nixBuildTargets = fmt.Sprintf("import \"%s\"", path)
-		}
-	} else if opts.NixBuildTarget != "" {
-		nixBuildTargets = fmt.Sprintf("{ \"out\" = %s; }", opts.NixBuildTarget)
-	}
-
-	ctx := getNixContext(opts)
-	resultPath, err = ctx.BuildMachines(deploymentPath, hosts, nixBuildTargets)
-
-	if err != nil {
-		return
-	}
-
-	fmt.Fprintln(os.Stderr, "nix result path: ")
-	fmt.Println(resultPath)
-	return
-}
-
-func pushPaths(sshContext *ssh.SSHContext, filteredHosts []nix.Host, resultPath string) error {
-	for _, host := range filteredHosts {
-		if host.BuildOnly {
-			fmt.Fprintf(os.Stderr, "Push is disabled for build-only host: %s\n", host.Name)
-			continue
-		}
-
-		paths, err := nix.GetPathsToPush(host, resultPath)
-		if err != nil {
-			return err
-		}
-		fmt.Fprintf(os.Stderr, "Pushing paths to %v (%v@%v):\n", host.Name, host.TargetUser, host.TargetHost)
-		for _, path := range paths {
-			fmt.Fprintf(os.Stderr, "\t* %s\n", path)
-		}
-		err = nix.Push(sshContext, host, paths...)
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func secretsUpload(opts *common.MorphOptions, ctx ssh.Context, filteredHosts []nix.Host, phase *string) error {
-	// upload secrets
-	// relative paths are resolved relative to the deployment file (!)
-	deploymentDir := filepath.Dir(opts.Deployment)
-	for _, host := range filteredHosts {
-		fmt.Fprintf(os.Stderr, "Uploading secrets to %s (%s):\n", host.Name, host.TargetHost)
-		postUploadActions := make(map[string][]string, 0)
-		for secretName, secret := range host.Secrets {
-			// if phase is nil, upload the secrets no matter what phase it wants
-			// if phase is non-nil, upload the secrets that match the specified phase
-			if phase != nil && secret.UploadAt != *phase {
-				continue
-			}
-
-			secretSize, err := secrets.GetSecretSize(secret, deploymentDir)
-			if err != nil {
-				return err
-			}
-
-			secretErr := secrets.UploadSecret(ctx, &host, secret, deploymentDir)
-			fmt.Fprintf(os.Stderr, "\t* %s (%d bytes).. ", secretName, secretSize)
-			if secretErr != nil {
-				if secretErr.Fatal {
-					fmt.Fprintln(os.Stderr, "Failed")
-					return secretErr
-				} else {
-					fmt.Fprintln(os.Stderr, "Partial")
-					fmt.Fprint(os.Stderr, secretErr.Error())
-				}
-			} else {
-				fmt.Fprintln(os.Stderr, "OK")
-			}
-			if len(secret.Action) > 0 {
-				// ensure each action is only run once
-				postUploadActions[strings.Join(secret.Action, " ")] = secret.Action
-			}
-		}
-		// Execute post-upload secret actions one-by-one after all secrets have been uploaded
-		for _, action := range postUploadActions {
-			fmt.Fprintf(os.Stderr, "\t- executing post-upload command: "+strings.Join(action, " ")+"\n")
-			// Errors from secret actions will be printed on screen, but we won't stop the flow if they fail
-			ctx.CmdInteractive(&host, opts.Timeout, action...)
-		}
-	}
-
-	return nil
-}
-
-func activateConfiguration(opts *common.MorphOptions, ctx ssh.Context, filteredHosts []nix.Host, resultPath string) error {
-	fmt.Fprintln(os.Stderr, "Executing '"+opts.DeploySwitchAction+"' on matched hosts:")
-	fmt.Fprintln(os.Stderr)
-	for _, host := range filteredHosts {
-
-		fmt.Fprintln(os.Stderr, "** "+host.Name)
-
-		configuration, err := nix.GetNixSystemPath(host, resultPath)
-		if err != nil {
-			return err
-		}
-
-		err = ctx.ActivateConfiguration(&host, configuration, opts.DeploySwitchAction)
-		if err != nil {
-			return err
-		}
-
-		fmt.Fprintln(os.Stderr)
-	}
-
-	return nil
 }

--- a/morph.go
+++ b/morph.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/DBCDK/morph/cliparser"
+	"github.com/DBCDK/morph/common"
 	"os"
 	"path/filepath"
 	"strings"

--- a/nix/nix.go
+++ b/nix/nix.go
@@ -14,6 +14,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/DBCDK/morph/common"
 	"github.com/DBCDK/morph/healthchecks"
 	"github.com/DBCDK/morph/secrets"
 	"github.com/DBCDK/morph/ssh"
@@ -517,4 +518,34 @@ func Push(ctx *ssh.SSHContext, host Host, paths ...string) (err error) {
 	}
 
 	return nil
+}
+
+func GetNixContext(opts *common.MorphOptions) *NixContext {
+	evalCmd := os.Getenv("MORPH_NIX_EVAL_CMD")
+	buildCmd := os.Getenv("MORPH_NIX_BUILD_CMD")
+	shellCmd := os.Getenv("MORPH_NIX_SHELL_CMD")
+	evalMachines := os.Getenv("MORPH_NIX_EVAL_MACHINES")
+
+	if evalCmd == "" {
+		evalCmd = "nix-instantiate"
+	}
+	if buildCmd == "" {
+		buildCmd = "nix-build"
+	}
+	if shellCmd == "" {
+		shellCmd = "nix-shell"
+	}
+	if evalMachines == "" {
+		evalMachines = filepath.Join(opts.AssetRoot, "eval-machines.nix")
+	}
+
+	return &NixContext{
+		EvalCmd:         evalCmd,
+		BuildCmd:        buildCmd,
+		ShellCmd:        shellCmd,
+		EvalMachines:    evalMachines,
+		ShowTrace:       opts.ShowTrace,
+		KeepGCRoot:      *opts.KeepGCRoot,
+		AllowBuildShell: *opts.AllowBuildShell,
+	}
 }

--- a/nix/nix.go
+++ b/nix/nix.go
@@ -64,7 +64,6 @@ type NixBuildInvocationArgs struct {
 	Attr            string
 	DeploymentPath  string
 	Names           []string
-	NixArgs         []string
 	NixBuildTargets string
 	NixConfig       map[string]string
 	NixContext      NixContext
@@ -81,10 +80,6 @@ func (nArgs *NixBuildInvocationArgs) ToNixBuildArgs() []string {
 	}
 
 	args = append(args, mkOptions(nArgs.NixConfig)...)
-
-	if len(nArgs.NixArgs) > 0 {
-		args = append(args, nArgs.NixArgs...)
-	}
 
 	if nArgs.NixContext.ShowTrace {
 		args = append(args, "--show-trace")
@@ -343,7 +338,7 @@ func (ctx *NixContext) GetMachines(deploymentPath string) (deployment Deployment
 	return deployment, nil
 }
 
-func (ctx *NixContext) BuildMachines(deploymentPath string, hosts []Host, nixArgs []string, nixBuildTargets string) (resultPath string, err error) {
+func (ctx *NixContext) BuildMachines(deploymentPath string, hosts []Host, nixBuildTargets string) (resultPath string, err error) {
 	tmpdir, err := ioutil.TempDir("", "morph-")
 	if err != nil {
 		return "", err
@@ -384,7 +379,6 @@ func (ctx *NixContext) BuildMachines(deploymentPath string, hosts []Host, nixArg
 		Attr:            "machines",
 		DeploymentPath:  deploymentPath,
 		Names:           hostNames,
-		NixArgs:         nixArgs,
 		NixBuildTargets: nixBuildTargets,
 		NixConfig:       hosts[0].NixConfig,
 		NixContext:      *ctx,
@@ -456,10 +450,6 @@ func mkOptions(nixConfig map[string]string) []string {
 
 func GetNixSystemPath(host Host, resultPath string) (string, error) {
 	return os.Readlink(filepath.Join(resultPath, host.Name))
-}
-
-func GetNixSystemDerivation(host Host, resultPath string) (string, error) {
-	return os.Readlink(filepath.Join(resultPath, host.Name+".drv"))
 }
 
 func GetPathsToPush(host Host, resultPath string) (paths []string, err error) {

--- a/ssh/ssh.go
+++ b/ssh/ssh.go
@@ -5,8 +5,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/DBCDK/morph/utils"
-	"golang.org/x/crypto/ssh/terminal"
 	"io"
 	"os"
 	"os/exec"
@@ -14,6 +12,11 @@ import (
 	"strings"
 	"syscall"
 	"time"
+
+	"golang.org/x/crypto/ssh/terminal"
+
+	"github.com/DBCDK/morph/common"
+	"github.com/DBCDK/morph/utils"
 )
 
 type Context interface {
@@ -46,6 +49,17 @@ type SSHContext struct {
 	IdentityFile           string
 	ConfigFile             string
 	SkipHostKeyCheck       bool
+}
+
+func CreateSSHContext(opts *common.MorphOptions) *SSHContext {
+	return &SSHContext{
+		AskForSudoPassword:     opts.AskForSudoPasswd,
+		GetSudoPasswordCommand: opts.PassCmd,
+		IdentityFile:           os.Getenv("SSH_IDENTITY_FILE"),
+		DefaultUsername:        os.Getenv("SSH_USER"),
+		SkipHostKeyCheck:       os.Getenv("SSH_SKIP_HOST_KEY_CHECK") != "",
+		ConfigFile:             os.Getenv("SSH_CONFIG_FILE"),
+	}
 }
 
 type FileTransfer struct {


### PR DESCRIPTION
**depends on #248, #249** 

fda48026b06b1f922757f32440335baa6bbc2f9d:
clean up `morph.go` by moving away a lot of deploy-related code. Much of this will have to be refactored down the line, so I've been a bit mean and moved it to a new package called `cruft`.

8766a86eefe594a54595ad5947500b2995ddb72e:
I'm not a fan of our usage of the term `context`/`ctx` all over the place, since that term usually refers to the golang `context` pkg. For now I've updated the naming to be consistent, so that vars called `ctx` is real golang contexts, while the other have gotten more appropriate and longer names (e.g. `sshContext` and `nixContext`). 