### PR TITLE
Allow passing the network directly to eval-machines.nix

### DIFF
--- a/data/eval-machines.nix
+++ b/data/eval-machines.nix
@@ -1,8 +1,10 @@
 # Completely stripped down version of nixops' evaluator
-{ networkExpr }:
+{ 
+  networkExpr ? null,
+  network ? import networkExpr,
+}:
 
 let
-  network = import networkExpr;
   nwPkgs = network.network.pkgs or { };
   lib = network.network.lib or nwPkgs.lib or (import <nixpkgs/lib>);
   evalConfig =


### PR DESCRIPTION
This PR allows users to re-use morph's `eval-machines.nix` with any amount of preprocessing since `networkExpr` is no longer a required argument if `network` is passed