### PR TITLE
ci: disable the non-functioning nix cache 

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -19,8 +19,6 @@ jobs:
         uses: actions/checkout@v4
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@main
-      - name: Setup Nix cache
-        uses: DeterminateSystems/magic-nix-cache-action@main
       - name: Morph Build ${{ Matrix.targets }}
         run: nix run . -- build examples/${{ matrix.targets }}
 
@@ -37,7 +35,5 @@ jobs:
 #        uses: actions/checkout@v4
 #      - name: Install Nix
 #        uses: DeterminateSystems/nix-installer-action@main
-#      - name: Setup Nix cache
-#        uses: DeterminateSystems/magic-nix-cache-action@main
 #      - name: Morph Build ${{ Matrix.targets }}
 #        run: nix run . -- build examples/${{ matrix.targets }}

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -22,8 +22,6 @@ jobs:
         uses: actions/checkout@v4
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@main
-      - name: Setup Nix cache
-        uses: DeterminateSystems/magic-nix-cache-action@main
       - name: Nix Flake Check
         run: nix build ./#checks.${{ matrix.systems }}.${{ matrix.checks }} -L
   macos:
@@ -41,7 +39,5 @@ jobs:
         uses: actions/checkout@v4
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@main
-      - name: Setup Nix cache
-        uses: DeterminateSystems/magic-nix-cache-action@main
       - name: Nix Flake Check
         run: nix build ./#checks.${{ matrix.systems }}.${{ matrix.checks }} -L


### PR DESCRIPTION
This removes the nix cache step from both workflows. In practice it doesn't do anything, other than removing the warning. Build times seem not-so-bad so maybe caching doesn't help that much anyways.